### PR TITLE
feat: Add ceil method for Quantity type and corresponding tests

### DIFF
--- a/qtty-core/src/quantity.rs
+++ b/qtty-core/src/quantity.rs
@@ -247,6 +247,12 @@ impl<U: Unit, S: Real> Quantity<U, S> {
         Self::new(self.0.sqrt())
     }
 
+    /// Returns the smallest integer quantity greater than or equal to this value.
+    #[inline]
+    pub fn ceil(self) -> Self {
+        Self::new(self.0.ceil())
+    }
+
     /// Checks equality with a quantity of a different unit in the same dimension.
     ///
     /// The `other` quantity is converted to unit `U` before comparison.

--- a/qtty-core/tests/core.rs
+++ b/qtty-core/tests/core.rs
@@ -49,6 +49,13 @@ fn quantity_abs() {
 }
 
 #[test]
+fn quantity_ceil() {
+    assert_eq!(TU::new(3.2).ceil().value(), 4.0);
+    assert_eq!(TU::new(-3.2).ceil().value(), -3.0);
+    assert_eq!(TU::new(5.0).ceil().value(), 5.0);
+}
+
+#[test]
 fn quantity_from_f64() {
     let q: TU = 123.456.into();
     assert_eq!(q.value(), 123.456);

--- a/qtty-core/tests/quantity_f32.rs
+++ b/qtty-core/tests/quantity_f32.rs
@@ -123,6 +123,13 @@ fn f32_quantity_sqrt() {
 }
 
 #[test]
+fn f32_quantity_ceil() {
+    assert_eq!(TU32::new(3.2).ceil().value(), 4.0_f32);
+    assert_eq!(TU32::new(-3.2).ceil().value(), -3.0_f32);
+    assert_eq!(TU32::new(5.0).ceil().value(), 5.0_f32);
+}
+
+#[test]
 fn f32_quantity_cast() {
     let q = TU32::new(42.5);
     let q_f64: Quantity<TestUnit, f64> = q.cast();


### PR DESCRIPTION
This pull request adds a new `ceil` method to the `Quantity` type, allowing users to obtain the smallest integer quantity greater than or equal to a value. Comprehensive tests for this method have been added for both `f64` and `f32` quantity types.

New feature: `ceil` method for `Quantity`

* Added a `ceil` method to `Quantity<U, S>` that returns the smallest integer quantity greater than or equal to the current value. (`qtty-core/src/quantity.rs`)

Testing enhancements

* Added tests for the new `ceil` method in `core.rs` for `f64` quantities. (`qtty-core/tests/core.rs`)
* Added tests for the new `ceil` method in `quantity_f32.rs` for `f32` quantities. (`qtty-core/tests/quantity_f32.rs`)