### PR TITLE
feat: Add Iterator::sum support for Quantity with tests for owned and…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and [Sem
 
 ### Added
 - Added support for operations with Rust built-in numeric types, improving ergonomics when combining `Quantity` values with primitive scalars.
+- Added `Iterator::sum` support for `Quantity`, including ergonomic accumulation into `f64` from iterators of `Quantity<_, f64>` (owned or borrowed items).
 - Full dimensional arithmetic support using compile-time exponent math (`Dim`, `DimMul`, `DimDiv`) powered by `typenum`.
 - New product unit type `Prod<A, B>` to represent unit multiplication (`Length * Length`, `Area * Length`, etc.).
 - New `area` unit module with metric, land, and imperial/US units (for example `SquareMeter`, `Hectare`, `Acre`).

--- a/qtty-core/src/quantity.rs
+++ b/qtty-core/src/quantity.rs
@@ -4,6 +4,7 @@ use crate::dimension::{DimDiv, DimMul, Dimension};
 use crate::scalar::{Exact, Real, Scalar, Transcendental};
 use crate::unit::{Per, Prod, Unit};
 use core::cmp::Ordering;
+use core::iter::Sum;
 use core::marker::PhantomData;
 use core::ops::*;
 
@@ -691,6 +692,36 @@ impl<U: Unit, S: Scalar> From<S> for Quantity<U, S> {
     #[inline]
     fn from(value: S) -> Self {
         Self::new(value)
+    }
+}
+
+// Sum quantities into a quantity of the same unit/scalar.
+impl<U: Unit, S: Scalar> Sum for Quantity<U, S> {
+    #[inline]
+    fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+        iter.fold(Self::zero(), |acc, q| acc + q)
+    }
+}
+
+impl<'a, U: Unit, S: Scalar> Sum<&'a Quantity<U, S>> for Quantity<U, S> {
+    #[inline]
+    fn sum<I: Iterator<Item = &'a Quantity<U, S>>>(iter: I) -> Self {
+        iter.fold(Self::zero(), |acc, q| acc + *q)
+    }
+}
+
+// Sum quantities directly into their raw scalar for ergonomic iterator use.
+impl<U: Unit> Sum<Quantity<U, f64>> for f64 {
+    #[inline]
+    fn sum<I: Iterator<Item = Quantity<U, f64>>>(iter: I) -> Self {
+        iter.fold(0.0, |acc, q| acc + q.value())
+    }
+}
+
+impl<'a, U: Unit> Sum<&'a Quantity<U, f64>> for f64 {
+    #[inline]
+    fn sum<I: Iterator<Item = &'a Quantity<U, f64>>>(iter: I) -> Self {
+        iter.fold(0.0, |acc, q| acc + q.value())
     }
 }
 

--- a/qtty-core/tests/core.rs
+++ b/qtty-core/tests/core.rs
@@ -174,6 +174,20 @@ fn operator_sub_assign() {
 }
 
 #[test]
+fn iterator_sum_quantity_owned() {
+    let values = vec![TU::new(1.0), TU::new(2.5), TU::new(3.5)];
+    let total: TU = values.into_iter().sum();
+    assert!((total.value() - 7.0).abs() < 1e-12);
+}
+
+#[test]
+fn iterator_sum_quantity_borrowed_to_f64() {
+    let values = [TU::new(1.0), TU::new(2.5), TU::new(3.5)];
+    let total: f64 = values.iter().sum();
+    assert!((total - 7.0).abs() < 1e-12);
+}
+
+#[test]
 fn operator_div_assign() {
     let mut q = TU::new(20.0);
     q /= TU::new(4.0);


### PR DESCRIPTION
This pull request adds ergonomic support for summing `Quantity` values using Rust's iterator traits, allowing both accumulation into a `Quantity` and direct accumulation into a primitive `f64` scalar. The changes include new trait implementations, updated documentation, and tests to ensure correctness.

Iterator sum support:

* Implemented `Sum` trait for `Quantity<U, S>`, enabling accumulation of owned and borrowed quantities into a single quantity via `.sum()` on iterators.
* Implemented `Sum` trait for accumulating `Quantity<U, f64>` (owned or borrowed) directly into an `f64`, allowing ergonomic iterator-based summation of quantity values.

Documentation:

* Updated `CHANGELOG.md` to document the new iterator sum support for `Quantity`, including accumulation into `f64` from iterators of `Quantity<_, f64>`.

Testing:

* Added tests in `core.rs` for summing owned quantities into a `Quantity` and summing borrowed quantities into an `f64`, verifying correctness of the new iterator sum functionality.

Dependency update:

* Added import of `core::iter::Sum` in `quantity.rs` to support the new trait implementations.… borrowed accumulation