### PR TITLE
Fix issue #11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 /target
+/qtty/target/
+/qtty-core/target/
+/qtty-derive/target/
+/qtty-ffi/target/
 
 coverage.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and [Sem
 ### Added
 - New `qtty` crate feature `alloc` for heap-backed helpers in `no_std` builds. (see #10)
 - Integration compile checks for `qtty::qtty_vec!` across `std`, `no_std + alloc`, and pure `no_std` modes. (see #10)
+- New integer scalar facade modules `qtty::i8`, `qtty::i16`, and `qtty::i128`, mirroring the unit aliases available in `qtty::i32`. (see #11)
 
 ### Fixed
 - `qtty::qtty_vec!(vec ...)` no longer hardcodes `std`; it now works with `alloc` in `no_std` builds. (see #10)
 - In pure `no_std` (without `alloc`), `qtty::qtty_vec!(vec ...)` now fails with a clear feature requirement message while array form continues to work. (see #10)
+- `qtty` crate docs now match the public integer module surface (`i8`, `i16`, `i32`, `i64`, `i128`) and include coverage for integer `to_lossy()` flows in facade integration tests. (see #11)
 
 ## [0.3.0] - 2026-02-09
 

--- a/qtty/src/i128.rs
+++ b/qtty/src/i128.rs
@@ -1,0 +1,111 @@
+//! Re-exports of quantity types specialized to `i128` scalar.
+//!
+//! This module provides type aliases for all unit types using `i128` as the
+//! underlying scalar type. Integer quantities provide compile-time unit safety
+//! for discrete values (counters, pixel coordinates, ADC readings, etc.).
+//!
+//! Integer quantities support basic arithmetic but **not** unit conversion via
+//! [`to()`](crate::Quantity::to). Use [`to_lossy()`](crate::Quantity::to_lossy)
+//! for lossy (truncating) conversion between units.
+//!
+//! # Example
+//!
+//! ```rust
+//! use qtty::i128::{Meters, Seconds};
+//!
+//! let distance: Meters = Meters::new(1500);
+//! let time: Seconds = Seconds::new(10);
+//! ```
+
+use crate::Quantity;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Angular units (i128)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Degrees with `i128` scalar.
+pub type Degrees = Quantity<crate::angular::Degree, i128>;
+/// Radians with `i128` scalar.
+pub type Radians = Quantity<crate::angular::Radian, i128>;
+/// Arcminutes with `i128` scalar.
+pub type Arcminutes = Quantity<crate::angular::Arcminute, i128>;
+/// Arcseconds with `i128` scalar.
+pub type Arcseconds = Quantity<crate::angular::Arcsecond, i128>;
+/// Milliradians with `i128` scalar.
+pub type Milliradians = Quantity<crate::angular::Milliradian, i128>;
+/// Milliarcseconds with `i128` scalar.
+pub type MilliArcseconds = Quantity<crate::angular::MilliArcsecond, i128>;
+/// Microarcseconds with `i128` scalar.
+pub type MicroArcseconds = Quantity<crate::angular::MicroArcsecond, i128>;
+/// Gradians with `i128` scalar.
+pub type Gradians = Quantity<crate::angular::Gradian, i128>;
+/// Turns with `i128` scalar.
+pub type Turns = Quantity<crate::angular::Turn, i128>;
+/// Hour angles with `i128` scalar.
+pub type HourAngles = Quantity<crate::angular::HourAngle, i128>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Length units (i128)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Meters with `i128` scalar.
+pub type Meters = Quantity<crate::length::Meter, i128>;
+/// Kilometers with `i128` scalar.
+pub type Kilometers = Quantity<crate::length::Kilometer, i128>;
+/// Centimeters with `i128` scalar.
+pub type Centimeters = Quantity<crate::length::Centimeter, i128>;
+/// Millimeters with `i128` scalar.
+pub type Millimeters = Quantity<crate::length::Millimeter, i128>;
+/// Micrometers with `i128` scalar.
+pub type Micrometers = Quantity<crate::length::Micrometer, i128>;
+/// Nanometers with `i128` scalar.
+pub type Nanometers = Quantity<crate::length::Nanometer, i128>;
+/// Astronomical units with `i128` scalar.
+pub type AstronomicalUnits = Quantity<crate::length::AstronomicalUnit, i128>;
+/// Light years with `i128` scalar.
+pub type LightYears = Quantity<crate::length::LightYear, i128>;
+/// Parsecs with `i128` scalar.
+pub type Parsecs = Quantity<crate::length::Parsec, i128>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Time units (i128)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Seconds with `i128` scalar.
+pub type Seconds = Quantity<crate::time::Second, i128>;
+/// Milliseconds with `i128` scalar.
+pub type Milliseconds = Quantity<crate::time::Millisecond, i128>;
+/// Microseconds with `i128` scalar.
+pub type Microseconds = Quantity<crate::time::Microsecond, i128>;
+/// Nanoseconds with `i128` scalar.
+pub type Nanoseconds = Quantity<crate::time::Nanosecond, i128>;
+/// Minutes with `i128` scalar.
+pub type Minutes = Quantity<crate::time::Minute, i128>;
+/// Hours with `i128` scalar.
+pub type Hours = Quantity<crate::time::Hour, i128>;
+/// Days with `i128` scalar.
+pub type Days = Quantity<crate::time::Day, i128>;
+/// Years with `i128` scalar.
+pub type Years = Quantity<crate::time::Year, i128>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mass units (i128)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Grams with `i128` scalar.
+pub type Grams = Quantity<crate::mass::Gram, i128>;
+/// Kilograms with `i128` scalar.
+pub type Kilograms = Quantity<crate::mass::Kilogram, i128>;
+/// Solar masses with `i128` scalar.
+pub type SolarMasses = Quantity<crate::mass::SolarMass, i128>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Power units (i128)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Watts with `i128` scalar.
+pub type Watts = Quantity<crate::power::Watt, i128>;
+/// Kilowatts with `i128` scalar.
+pub type Kilowatts = Quantity<crate::power::Kilowatt, i128>;
+/// Solar luminosities with `i128` scalar.
+pub type SolarLuminosities = Quantity<crate::power::SolarLuminosity, i128>;

--- a/qtty/src/i16.rs
+++ b/qtty/src/i16.rs
@@ -1,0 +1,111 @@
+//! Re-exports of quantity types specialized to `i16` scalar.
+//!
+//! This module provides type aliases for all unit types using `i16` as the
+//! underlying scalar type. Integer quantities provide compile-time unit safety
+//! for discrete values (counters, pixel coordinates, ADC readings, etc.).
+//!
+//! Integer quantities support basic arithmetic but **not** unit conversion via
+//! [`to()`](crate::Quantity::to). Use [`to_lossy()`](crate::Quantity::to_lossy)
+//! for lossy (truncating) conversion between units.
+//!
+//! # Example
+//!
+//! ```rust
+//! use qtty::i16::{Meters, Seconds};
+//!
+//! let distance: Meters = Meters::new(1500);
+//! let time: Seconds = Seconds::new(10);
+//! ```
+
+use crate::Quantity;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Angular units (i16)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Degrees with `i16` scalar.
+pub type Degrees = Quantity<crate::angular::Degree, i16>;
+/// Radians with `i16` scalar.
+pub type Radians = Quantity<crate::angular::Radian, i16>;
+/// Arcminutes with `i16` scalar.
+pub type Arcminutes = Quantity<crate::angular::Arcminute, i16>;
+/// Arcseconds with `i16` scalar.
+pub type Arcseconds = Quantity<crate::angular::Arcsecond, i16>;
+/// Milliradians with `i16` scalar.
+pub type Milliradians = Quantity<crate::angular::Milliradian, i16>;
+/// Milliarcseconds with `i16` scalar.
+pub type MilliArcseconds = Quantity<crate::angular::MilliArcsecond, i16>;
+/// Microarcseconds with `i16` scalar.
+pub type MicroArcseconds = Quantity<crate::angular::MicroArcsecond, i16>;
+/// Gradians with `i16` scalar.
+pub type Gradians = Quantity<crate::angular::Gradian, i16>;
+/// Turns with `i16` scalar.
+pub type Turns = Quantity<crate::angular::Turn, i16>;
+/// Hour angles with `i16` scalar.
+pub type HourAngles = Quantity<crate::angular::HourAngle, i16>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Length units (i16)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Meters with `i16` scalar.
+pub type Meters = Quantity<crate::length::Meter, i16>;
+/// Kilometers with `i16` scalar.
+pub type Kilometers = Quantity<crate::length::Kilometer, i16>;
+/// Centimeters with `i16` scalar.
+pub type Centimeters = Quantity<crate::length::Centimeter, i16>;
+/// Millimeters with `i16` scalar.
+pub type Millimeters = Quantity<crate::length::Millimeter, i16>;
+/// Micrometers with `i16` scalar.
+pub type Micrometers = Quantity<crate::length::Micrometer, i16>;
+/// Nanometers with `i16` scalar.
+pub type Nanometers = Quantity<crate::length::Nanometer, i16>;
+/// Astronomical units with `i16` scalar.
+pub type AstronomicalUnits = Quantity<crate::length::AstronomicalUnit, i16>;
+/// Light years with `i16` scalar.
+pub type LightYears = Quantity<crate::length::LightYear, i16>;
+/// Parsecs with `i16` scalar.
+pub type Parsecs = Quantity<crate::length::Parsec, i16>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Time units (i16)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Seconds with `i16` scalar.
+pub type Seconds = Quantity<crate::time::Second, i16>;
+/// Milliseconds with `i16` scalar.
+pub type Milliseconds = Quantity<crate::time::Millisecond, i16>;
+/// Microseconds with `i16` scalar.
+pub type Microseconds = Quantity<crate::time::Microsecond, i16>;
+/// Nanoseconds with `i16` scalar.
+pub type Nanoseconds = Quantity<crate::time::Nanosecond, i16>;
+/// Minutes with `i16` scalar.
+pub type Minutes = Quantity<crate::time::Minute, i16>;
+/// Hours with `i16` scalar.
+pub type Hours = Quantity<crate::time::Hour, i16>;
+/// Days with `i16` scalar.
+pub type Days = Quantity<crate::time::Day, i16>;
+/// Years with `i16` scalar.
+pub type Years = Quantity<crate::time::Year, i16>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mass units (i16)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Grams with `i16` scalar.
+pub type Grams = Quantity<crate::mass::Gram, i16>;
+/// Kilograms with `i16` scalar.
+pub type Kilograms = Quantity<crate::mass::Kilogram, i16>;
+/// Solar masses with `i16` scalar.
+pub type SolarMasses = Quantity<crate::mass::SolarMass, i16>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Power units (i16)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Watts with `i16` scalar.
+pub type Watts = Quantity<crate::power::Watt, i16>;
+/// Kilowatts with `i16` scalar.
+pub type Kilowatts = Quantity<crate::power::Kilowatt, i16>;
+/// Solar luminosities with `i16` scalar.
+pub type SolarLuminosities = Quantity<crate::power::SolarLuminosity, i16>;

--- a/qtty/src/i8.rs
+++ b/qtty/src/i8.rs
@@ -1,0 +1,111 @@
+//! Re-exports of quantity types specialized to `i8` scalar.
+//!
+//! This module provides type aliases for all unit types using `i8` as the
+//! underlying scalar type. Integer quantities provide compile-time unit safety
+//! for discrete values (counters, pixel coordinates, ADC readings, etc.).
+//!
+//! Integer quantities support basic arithmetic but **not** unit conversion via
+//! [`to()`](crate::Quantity::to). Use [`to_lossy()`](crate::Quantity::to_lossy)
+//! for lossy (truncating) conversion between units.
+//!
+//! # Example
+//!
+//! ```rust
+//! use qtty::i8::{Meters, Seconds};
+//!
+//! let distance: Meters = Meters::new(120);
+//! let time: Seconds = Seconds::new(10);
+//! ```
+
+use crate::Quantity;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Angular units (i8)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Degrees with `i8` scalar.
+pub type Degrees = Quantity<crate::angular::Degree, i8>;
+/// Radians with `i8` scalar.
+pub type Radians = Quantity<crate::angular::Radian, i8>;
+/// Arcminutes with `i8` scalar.
+pub type Arcminutes = Quantity<crate::angular::Arcminute, i8>;
+/// Arcseconds with `i8` scalar.
+pub type Arcseconds = Quantity<crate::angular::Arcsecond, i8>;
+/// Milliradians with `i8` scalar.
+pub type Milliradians = Quantity<crate::angular::Milliradian, i8>;
+/// Milliarcseconds with `i8` scalar.
+pub type MilliArcseconds = Quantity<crate::angular::MilliArcsecond, i8>;
+/// Microarcseconds with `i8` scalar.
+pub type MicroArcseconds = Quantity<crate::angular::MicroArcsecond, i8>;
+/// Gradians with `i8` scalar.
+pub type Gradians = Quantity<crate::angular::Gradian, i8>;
+/// Turns with `i8` scalar.
+pub type Turns = Quantity<crate::angular::Turn, i8>;
+/// Hour angles with `i8` scalar.
+pub type HourAngles = Quantity<crate::angular::HourAngle, i8>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Length units (i8)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Meters with `i8` scalar.
+pub type Meters = Quantity<crate::length::Meter, i8>;
+/// Kilometers with `i8` scalar.
+pub type Kilometers = Quantity<crate::length::Kilometer, i8>;
+/// Centimeters with `i8` scalar.
+pub type Centimeters = Quantity<crate::length::Centimeter, i8>;
+/// Millimeters with `i8` scalar.
+pub type Millimeters = Quantity<crate::length::Millimeter, i8>;
+/// Micrometers with `i8` scalar.
+pub type Micrometers = Quantity<crate::length::Micrometer, i8>;
+/// Nanometers with `i8` scalar.
+pub type Nanometers = Quantity<crate::length::Nanometer, i8>;
+/// Astronomical units with `i8` scalar.
+pub type AstronomicalUnits = Quantity<crate::length::AstronomicalUnit, i8>;
+/// Light years with `i8` scalar.
+pub type LightYears = Quantity<crate::length::LightYear, i8>;
+/// Parsecs with `i8` scalar.
+pub type Parsecs = Quantity<crate::length::Parsec, i8>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Time units (i8)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Seconds with `i8` scalar.
+pub type Seconds = Quantity<crate::time::Second, i8>;
+/// Milliseconds with `i8` scalar.
+pub type Milliseconds = Quantity<crate::time::Millisecond, i8>;
+/// Microseconds with `i8` scalar.
+pub type Microseconds = Quantity<crate::time::Microsecond, i8>;
+/// Nanoseconds with `i8` scalar.
+pub type Nanoseconds = Quantity<crate::time::Nanosecond, i8>;
+/// Minutes with `i8` scalar.
+pub type Minutes = Quantity<crate::time::Minute, i8>;
+/// Hours with `i8` scalar.
+pub type Hours = Quantity<crate::time::Hour, i8>;
+/// Days with `i8` scalar.
+pub type Days = Quantity<crate::time::Day, i8>;
+/// Years with `i8` scalar.
+pub type Years = Quantity<crate::time::Year, i8>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mass units (i8)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Grams with `i8` scalar.
+pub type Grams = Quantity<crate::mass::Gram, i8>;
+/// Kilograms with `i8` scalar.
+pub type Kilograms = Quantity<crate::mass::Kilogram, i8>;
+/// Solar masses with `i8` scalar.
+pub type SolarMasses = Quantity<crate::mass::SolarMass, i8>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Power units (i8)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Watts with `i8` scalar.
+pub type Watts = Quantity<crate::power::Watt, i8>;
+/// Kilowatts with `i8` scalar.
+pub type Kilowatts = Quantity<crate::power::Kilowatt, i8>;
+/// Solar luminosities with `i8` scalar.
+pub type SolarLuminosities = Quantity<crate::power::SolarLuminosity, i8>;

--- a/qtty/src/lib.rs
+++ b/qtty/src/lib.rs
@@ -68,7 +68,8 @@
 //!
 //! - `f64` (default) - double precision floating point
 //! - `f32` - single precision floating point (use `qtty::f32::*`)
-//! - `i8`, `i16`, `i32`, `i64`, `i128` - signed integers (use `qtty::i32::*`, `qtty::i64::*`, etc.)
+//! - `i8`, `i16`, `i32`, `i64`, `i128` - signed integers
+//!   (use `qtty::i8::*`, `qtty::i16::*`, `qtty::i32::*`, `qtty::i64::*`, `qtty::i128::*`)
 //! - `Decimal` - exact decimal (feature `scalar-decimal`)
 //! - `Rational64` - exact rational (feature `scalar-rational`)
 //!
@@ -90,8 +91,11 @@
 //! - `qtty::frequency` (`Angular / Time` aliases)
 //! - `qtty::f32` (all units with `f32` scalar)
 //! - `qtty::f64` (all units with `f64` scalar - same as root)
+//! - `qtty::i8` (all units with `i8` scalar)
+//! - `qtty::i16` (all units with `i16` scalar)
 //! - `qtty::i32` (all units with `i32` scalar)
 //! - `qtty::i64` (all units with `i64` scalar)
+//! - `qtty::i128` (all units with `i128` scalar)
 //!
 //! # Feature flags
 //!
@@ -144,8 +148,11 @@ pub use qtty_derive::Unit;
 
 pub mod f32;
 pub mod f64;
+pub mod i128;
+pub mod i16;
 pub mod i32;
 pub mod i64;
+pub mod i8;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Unit modules (grouped by dimension)

--- a/qtty/tests/integration_tests.rs
+++ b/qtty/tests/integration_tests.rs
@@ -412,3 +412,45 @@ fn smoke_test_f32_trig() {
     assert!((angle.sin() - 1.0).abs() < 1e-5);
     assert!(angle.cos().abs() < 1e-5);
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Integer scalar module tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn smoke_test_i8_module_arithmetic_and_lossy_conversion() {
+    use qtty::i8::{Meters, Minutes, Seconds};
+
+    let a = Meters::new(50);
+    let b = Meters::new(20);
+    assert_eq!((a + b).value(), 70);
+    assert_eq!((a - b).value(), 30);
+
+    let sec = Seconds::new(125);
+    let min: Minutes = sec.to_lossy();
+    assert_eq!(min.value(), 2);
+}
+
+#[test]
+fn smoke_test_i16_module_arithmetic_and_lossy_conversion() {
+    use qtty::i16::{Kilometers, Meters};
+
+    let a = Meters::new(1_500);
+    let b = Meters::new(250);
+    assert_eq!((a + b).value(), 1_750);
+
+    let km: Kilometers = a.to_lossy();
+    assert_eq!(km.value(), 1);
+}
+
+#[test]
+fn smoke_test_i128_module_arithmetic_and_lossy_conversion() {
+    use qtty::i128::{Days, Seconds};
+
+    let a = Seconds::new(172_800);
+    let b = Seconds::new(3_600);
+    assert_eq!((a + b).value(), 176_400);
+
+    let days: Days = a.to_lossy();
+    assert_eq!(days.value(), 2);
+}


### PR DESCRIPTION
This pull request adds new integer scalar facade modules to the `qtty` crate, providing type-safe quantity aliases for all units using `i8`, `i16`, and `i128` scalar types. It also updates documentation and adds integration tests to ensure correct arithmetic and lossy conversion behavior for these new modules.

**New integer scalar modules:**

- Introduced `qtty::i8`, `qtty::i16`, and `qtty::i128` modules, each re-exporting all quantity types specialized for their respective integer scalar types. This mirrors the existing structure for `i32` and other types, enabling compile-time unit safety for discrete integer values. [[1]](diffhunk://#diff-b1562000ca7f09ae6ca0f122a1acfe13798173a4a831a4ecce23fb0c9e4192daR1-R111) [[2]](diffhunk://#diff-6acea0bed8fab90ee01c4662602641bc8177542fac6ba56b09c965be201f523cR1-R111) [[3]](diffhunk://#diff-9adc332f766d9a4d0fd29c5429cf344953eb2e95eb22fe8cfb4233bebb455ac4R1-R111) [[4]](diffhunk://#diff-da07603ed892a06c9a1cab77df3ce0ed65d7f0b1b7b8b3850de06cb54c015001R151-R155)
- Updated crate documentation and module listings to include the new `i8`, `i16`, and `i128` modules, ensuring discoverability and consistency in the public API. [[1]](diffhunk://#diff-da07603ed892a06c9a1cab77df3ce0ed65d7f0b1b7b8b3850de06cb54c015001L71-R72) [[2]](diffhunk://#diff-da07603ed892a06c9a1cab77df3ce0ed65d7f0b1b7b8b3850de06cb54c015001R94-R98)

**Testing and documentation improvements:**

- Added integration tests to verify basic arithmetic and lossy unit conversion for the new integer modules, ensuring correct functionality and coverage.
- Improved documentation to match the expanded public integer module surface and clarified integer `to_lossy()` flows in integration tests.