### PR TITLE
Fix issue #12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and [Sem
 - `qtty::qtty_vec!(vec ...)` no longer hardcodes `std`; it now works with `alloc` in `no_std` builds. (see #10)
 - In pure `no_std` (without `alloc`), `qtty::qtty_vec!(vec ...)` now fails with a clear feature requirement message while array form continues to work. (see #10)
 - `qtty` crate docs now match the public integer module surface (`i8`, `i16`, `i32`, `i64`, `i128`) and include coverage for integer `to_lossy()` flows in facade integration tests. (see #11)
+- Unit-erasure conversion into `Quantity<Unitless>` is no longer limited to length units; time, mass, angular, and other supported non-dimensionless units now convert while preserving the raw scalar value (no normalization). (see #12)
 
 ## [0.3.0] - 2026-02-09
 

--- a/qtty/tests/integration_tests.rs
+++ b/qtty/tests/integration_tests.rs
@@ -61,6 +61,27 @@ fn smoke_test_unitless() {
 }
 
 #[test]
+fn smoke_test_unitless_from_time() {
+    let s = Seconds::new(5.0);
+    let u: Quantity<Unitless> = s.into();
+    assert_eq!(u.value(), 5.0);
+}
+
+#[test]
+fn smoke_test_unitless_from_mass() {
+    let kg = Kilograms::new(2.0);
+    let u: Quantity<Unitless> = kg.into();
+    assert_eq!(u.value(), 2.0);
+}
+
+#[test]
+fn smoke_test_unitless_from_angular() {
+    let deg = Degrees::new(15.0);
+    let u: Quantity<Unitless> = deg.into();
+    assert_eq!(u.value(), 15.0);
+}
+
+#[test]
 fn orbital_distance_calculation() {
     // Earth's orbital velocity ≈ 29.78 km/s
     let earth_velocity: velocity::Velocity<Kilometer, Second> = velocity::Velocity::new(29.78);


### PR DESCRIPTION
This pull request expands and generalizes the conversion of dimensioned quantities into unitless quantities within the `qtty` crate. Previously, only length units could be converted into `Quantity<Unitless>`, but now the conversion supports time, mass, angular, and other dimensioned units, always preserving the raw scalar value (without normalization). Comprehensive tests have been added to ensure correctness for the newly supported units.

**Generalization of unit-erasure conversion:**

* The conversion from dimensioned quantities to `Quantity<Unitless>` is no longer limited to length units; it now supports time, mass, angular, and other dimensioned units, preserving the scalar value without normalization. [[1]](diffhunk://#diff-59945dbafc8a3d7707a57982088c9ffc5d4be0c5e88126d349fb77c0a72e540fL5-R59) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR17)

**Testing improvements:**

* Added new unit tests in `qtty-core/src/units/unitless.rs` for time, mass, and angular conversions, including checks for non-default scalar types. [[1]](diffhunk://#diff-59945dbafc8a3d7707a57982088c9ffc5d4be0c5e88126d349fb77c0a72e540fL69-R99) [[2]](diffhunk://#diff-59945dbafc8a3d7707a57982088c9ffc5d4be0c5e88126d349fb77c0a72e540fR109-R136)
* Added property-based tests to ensure value preservation for time unit conversions.
* Added integration tests for unitless conversion from time, mass, and angular units in `qtty/tests/integration_tests.rs`.