### PR TITLE
Fix issue #14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and [Sem
 - In pure `no_std` (without `alloc`), `qtty::qtty_vec!(vec ...)` now fails with a clear feature requirement message while array form continues to work. (see #10)
 - `qtty` crate docs now match the public integer module surface (`i8`, `i16`, `i32`, `i64`, `i128`) and include coverage for integer `to_lossy()` flows in facade integration tests. (see #11)
 - Unit-erasure conversion into `Quantity<Unitless>` is no longer limited to length units; time, mass, angular, and other supported non-dimensionless units now convert while preserving the raw scalar value (no normalization). (see #12)
+- Removed `DivAssign<Self>` for `Quantity` because `quantity /= quantity` is dimensionally unsound; `/=` is now scalar-only (`DivAssign<S>`). Migration: replace `q /= other_q` with `q = (q / other_q).simplify()` when you need a unitless ratio, or use explicit scalar division where appropriate. (see #14)
 
 ## [0.3.0] - 2026-02-09
 

--- a/qtty-core/src/lib.rs
+++ b/qtty-core/src/lib.rs
@@ -384,7 +384,7 @@ mod tests {
     #[test]
     fn operator_div_assign() {
         let mut q = TU::new(20.0);
-        q /= TU::new(4.0);
+        q /= 4.0;
         assert_eq!(q.value(), 5.0);
     }
 

--- a/qtty-core/src/quantity.rs
+++ b/qtty-core/src/quantity.rs
@@ -565,10 +565,26 @@ impl<U: Unit, S: Scalar> Div<S> for Quantity<U, S> {
     }
 }
 
-impl<U: Unit, S: Scalar> DivAssign<Self> for Quantity<U, S> {
+impl<U: Unit, S: Scalar> DivAssign<S> for Quantity<U, S> {
+    /// In-place scalar division.
+    ///
+    /// ```rust
+    /// use qtty_core::length::Meters;
+    ///
+    /// let mut d = Meters::new(120.0);
+    /// d /= 60.0;
+    /// assert_eq!(d.value(), 2.0);
+    /// ```
+    ///
+    /// ```compile_fail
+    /// use qtty_core::length::Meters;
+    ///
+    /// let mut d = Meters::new(120.0);
+    /// d /= Meters::new(60.0);
+    /// ```
     #[inline]
-    fn div_assign(&mut self, rhs: Self) {
-        self.0 /= rhs.0;
+    fn div_assign(&mut self, rhs: S) {
+        self.0 /= rhs;
     }
 }
 

--- a/qtty-core/tests/core.rs
+++ b/qtty-core/tests/core.rs
@@ -190,7 +190,7 @@ fn iterator_sum_quantity_borrowed_to_f64() {
 #[test]
 fn operator_div_assign() {
     let mut q = TU::new(20.0);
-    q /= TU::new(4.0);
+    q /= 4.0;
     assert_eq!(q.value(), 5.0);
 }
 

--- a/qtty-core/tests/integers.rs
+++ b/qtty-core/tests/integers.rs
@@ -360,8 +360,7 @@ fn test_i32_negative_quantities() {
 #[test]
 fn test_i32_div_assign() {
     let mut a = Quantity::<Meter, i32>::new(10);
-    let b = Quantity::<Meter, i32>::new(5);
-    a /= b;
+    a /= 5;
     assert_eq!(a.value(), 2);
 }
 

--- a/qtty-core/tests/quantity_f32.rs
+++ b/qtty-core/tests/quantity_f32.rs
@@ -261,7 +261,7 @@ fn f32_sub_assign() {
 #[test]
 fn f32_div_assign() {
     let mut q = TU32::new(20.0);
-    q /= TU32::new(4.0);
+    q /= 4.0_f32;
     assert_eq!(q.value(), 5.0_f32);
 }
 


### PR DESCRIPTION
This pull request removes the ability to use the `/=` operator between two `Quantity` values, as this operation is dimensionally incorrect. Now, `/=` is only allowed between a `Quantity` and a scalar. Tests and documentation have been updated to reflect this change.

**Breaking change to division assignment:**

* Removed the `DivAssign<Self>` implementation for `Quantity`, so `quantity /= quantity` is no longer allowed; `/=` now only works with scalars (`DivAssign<S>`). To divide by another quantity and get a unitless ratio, use `q = (q / other_q).simplify()`. [[1]](diffhunk://#diff-0ab8321b7588cdac5b6f13fb1a61cbbcb693b8ee28c4d929555f9a9a9d4067c4L568-R587) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR18)

**Test and documentation updates:**

* Updated tests in `qtty-core/src/lib.rs`, `qtty-core/tests/core.rs`, `qtty-core/tests/integers.rs`, and `qtty-core/tests/quantity_f32.rs` to use scalar division assignment (`q /= scalar`) instead of quantity division assignment. [[1]](diffhunk://#diff-98520a8163976ce5aeb2ad25dfaec18431f15a372a7d887cf2aa18ce03ab9598L387-R387) [[2]](diffhunk://#diff-953609e35ff0ad3dc9fda802d6031d70f25217f22e48df1561e9f299ff57a226L193-R193) [[3]](diffhunk://#diff-c2c75b8132274e3d2eb1ae4b98de187384947f79e0f8bd66bdb82bac52b89dedL363-R363) [[4]](diffhunk://#diff-224362f05a19ee2dd47716c834867b2236e392cee5cd59fa50de87e1b5a49f2eL264-R264)
* Added documentation and compile-fail example to clarify that `/=` with another `Quantity` is not allowed.