### PR TITLE
Fix issue 15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,42 @@ jobs:
       - run: cargo test --all-targets
       - run: cargo test --doc
 
+  no-cross-unit-ops:
+    name: No Cross-Unit Ops
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Validate conversions and eq_unit/cmp_unit in reduced mode
+        run: cargo test -p qtty-core --test core --test no_cross_unit_ops --no-default-features --features std
+      - name: Ensure direct cross-unit operators are disabled in reduced mode
+        run: |
+          tmpdir="$(mktemp -d)"
+          cat > "$tmpdir/Cargo.toml" <<EOF
+          [package]
+          name = "no-cross-unit-ops-check"
+          version = "0.0.0"
+          edition = "2021"
+
+          [dependencies]
+          qtty-core = { path = "$PWD/qtty-core", default-features = false, features = ["std"] }
+          EOF
+          mkdir -p "$tmpdir/src"
+          cat > "$tmpdir/src/main.rs" <<'EOF'
+          use qtty_core::length::{Kilometers, Meters};
+
+          fn main() {
+              let km = Kilometers::new(1.0);
+              let m = Meters::new(500.0);
+              let _ = km > m;
+          }
+          EOF
+
+          if cargo check --manifest-path "$tmpdir/Cargo.toml"; then
+            echo "cross-unit operators unexpectedly compiled with cross-unit-ops disabled"
+            exit 1
+          fi
+
   coverage:
     name: Test & Coverage
     if: ${{ github.event_name == 'push' || github.event.pull_request.draft == false }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and [Sem
 - New `qtty` crate feature `alloc` for heap-backed helpers in `no_std` builds. (see #10)
 - Integration compile checks for `qtty::qtty_vec!` across `std`, `no_std + alloc`, and pure `no_std` modes. (see #10)
 - New integer scalar facade modules `qtty::i8`, `qtty::i16`, and `qtty::i128`, mirroring the unit aliases available in `qtty::i32`. (see #11)
+- New `cross-unit-ops` feature in `qtty-core` and `qtty` (enabled by default) to gate generation of direct cross-unit comparison operator impls (`==`, `<`, etc.). (see #15)
+- New reduced-mode CI profile (`No Cross-Unit Ops`) plus targeted compile checks validating `eq_unit`/`cmp_unit` and ensuring direct cross-unit operators are disabled when the feature is off. (see #15)
+- Documented compile-time benchmark commands (`cargo +nightly -Z timings`) for comparing default and reduced-mode builds. (see #15)
 
 ### Fixed
 - `qtty::qtty_vec!(vec ...)` no longer hardcodes `std`; it now works with `alloc` in `no_std` builds. (see #10)
@@ -16,6 +19,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and [Sem
 - `qtty` crate docs now match the public integer module surface (`i8`, `i16`, `i32`, `i64`, `i128`) and include coverage for integer `to_lossy()` flows in facade integration tests. (see #11)
 - Unit-erasure conversion into `Quantity<Unitless>` is no longer limited to length units; time, mass, angular, and other supported non-dimensionless units now convert while preserving the raw scalar value (no normalization). (see #12)
 - Removed `DivAssign<Self>` for `Quantity` because `quantity /= quantity` is dimensionally unsound; `/=` is now scalar-only (`DivAssign<S>`). Migration: replace `q /= other_q` with `q = (q / other_q).simplify()` when you need a unitless ratio, or use explicit scalar division where appropriate. (see #14)
+- Reduced quadratic impl bloat in built-in unit catalogs by splitting conversion generation from cross-unit comparison generation; reduced mode now keeps `From` conversions while omitting cross-unit operator impls. (see #15)
 
 ## [0.3.0] - 2026-02-09
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ assert!((r.value() - core::f64::consts::PI).abs() < 1e-12);
 ## Features
 
 - `std` (default): enables `std` support in `qtty-core`.
+- `cross-unit-ops` (default): enables direct cross-unit comparison operators (`==`, `<`, etc.) for built-in units.
 - `alloc`: enables heap-backed helpers (including `qtty::qtty_vec!(vec ...)`) in `no_std`.
 - `serde`: serializes/deserializes `Quantity<U>` as bare `f64` values.
 - `pyo3`: enables PyO3 conversions for `Quantity<U>` and `#[pyclass]` interop.

--- a/qtty-core/Cargo.toml
+++ b/qtty-core/Cargo.toml
@@ -12,8 +12,9 @@ readme = "README.md"
 documentation = "https://docs.rs/qtty-core"
 
 [features]
-default = ["std"]
+default = ["std", "cross-unit-ops"]
 std = []
+cross-unit-ops = []
 serde = ["dep:serde"]
 
 # Optional support

--- a/qtty-core/README.md
+++ b/qtty-core/README.md
@@ -76,8 +76,18 @@ qtty-core = { version = "0.1.0", default-features = false }
 ## Feature flags
 
 - `std` (default): enables `std` support.
+- `cross-unit-ops` (default): enables direct cross-unit comparison operators (`==`, `<`, etc.) for built-in unit sets.
 - `serde`: serializes/deserializes `Quantity<U>` as bare `f64` values.
 - `pyo3`: enables PyO3 conversions for `Quantity<U>` and Python interop traits.
+
+## Compile-time timings
+
+Compare default vs reduced cross-unit-ops mode:
+
+```bash
+cargo +nightly check -p qtty --all-targets -Z timings
+cargo +nightly check -p qtty --all-targets --no-default-features --features std -Z timings
+```
 
 ## License
 

--- a/qtty-core/src/lib.rs
+++ b/qtty-core/src/lib.rs
@@ -60,6 +60,7 @@
 //! # Feature flags
 //!
 //! - `std` (default): enables `std` support.
+//! - `cross-unit-ops` (default): enables direct cross-unit comparison operators (`==`, `<`, etc.) for built-in unit catalogs.
 //! - `serde`: enables `serde` support for `Quantity<U>`; serialization is the raw `f64` value only.
 //! - `pyo3`: enables PyO3 bindings for Python interop via `#[pyclass]` and `#[pymethods]`.
 //!

--- a/qtty-core/src/units/angular.rs
+++ b/qtty-core/src/units/angular.rs
@@ -398,8 +398,23 @@ impl Degrees {
     }
 }
 
-// Generate all bidirectional From implementations between angular units
-crate::impl_unit_conversions!(
+// Generate all bidirectional From implementations between angular units.
+crate::impl_unit_from_conversions!(
+    Degree,
+    Radian,
+    Milliradian,
+    Arcminute,
+    Arcsecond,
+    MilliArcsecond,
+    MicroArcsecond,
+    Gradian,
+    Turn,
+    HourAngle
+);
+
+// Optional cross-unit operator support (`==`, `<`, etc.).
+#[cfg(feature = "cross-unit-ops")]
+crate::impl_unit_cross_unit_ops!(
     Degree,
     Radian,
     Milliradian,

--- a/qtty-core/src/units/length.rs
+++ b/qtty-core/src/units/length.rs
@@ -555,7 +555,9 @@ pub mod nominal {
     // Allow convenient conversions between selected nominal units and core
     // length units (e.g., SolarRadius <-> Kilometer) without polluting the
     // main length namespace with nominal types.
-    crate::impl_unit_conversions!(SolarRadius, Kilometer);
+    crate::impl_unit_from_conversions!(SolarRadius, Kilometer);
+    #[cfg(feature = "cross-unit-ops")]
+    crate::impl_unit_cross_unit_ops!(SolarRadius, Kilometer);
 }
 
 // Generate all bidirectional From implementations between length units.
@@ -563,7 +565,54 @@ pub mod nominal {
 // This single invocation ensures that any quantity measured in one length unit can be
 // converted into any other via `From`/`Into`, mirroring the previous behavior while
 // including the extended unit set.
-crate::impl_unit_conversions!(
+crate::impl_unit_from_conversions!(
+    Meter,
+    Decimeter,
+    Centimeter,
+    Millimeter,
+    Micrometer,
+    Nanometer,
+    Picometer,
+    Femtometer,
+    Attometer,
+    Zeptometer,
+    Yoctometer,
+    Decameter,
+    Hectometer,
+    Kilometer,
+    Megameter,
+    Gigameter,
+    Terameter,
+    Petameter,
+    Exameter,
+    Zettameter,
+    Yottameter,
+    AstronomicalUnit,
+    LightYear,
+    Parsec,
+    Kiloparsec,
+    Megaparsec,
+    Gigaparsec,
+    Inch,
+    Foot,
+    Yard,
+    Mile,
+    NauticalMile,
+    Chain,
+    Rod,
+    Link,
+    Fathom,
+    EarthMeridionalCircumference,
+    EarthEquatorialCircumference,
+    BohrRadius,
+    ClassicalElectronRadius,
+    PlanckLength,
+    ElectronReducedComptonWavelength
+);
+
+// Optional cross-unit operator support (`==`, `<`, etc.).
+#[cfg(feature = "cross-unit-ops")]
+crate::impl_unit_cross_unit_ops!(
     Meter,
     Decimeter,
     Centimeter,

--- a/qtty-core/src/units/mass.rs
+++ b/qtty-core/src/units/mass.rs
@@ -194,8 +194,44 @@ pub type SolarMasses = Quantity<SolarMass>;
 /// One nominal solar mass.
 pub const MSUN: SolarMasses = SolarMasses::new(1.0);
 
-// Generate all bidirectional From implementations between mass units
-crate::impl_unit_conversions!(
+// Generate all bidirectional From implementations between mass units.
+crate::impl_unit_from_conversions!(
+    Gram,
+    Yoctogram,
+    Zeptogram,
+    Attogram,
+    Femtogram,
+    Picogram,
+    Nanogram,
+    Microgram,
+    Milligram,
+    Centigram,
+    Decigram,
+    Decagram,
+    Hectogram,
+    Kilogram,
+    Megagram,
+    Gigagram,
+    Teragram,
+    Petagram,
+    Exagram,
+    Zettagram,
+    Yottagram,
+    Tonne,
+    Carat,
+    Grain,
+    Pound,
+    Ounce,
+    Stone,
+    ShortTon,
+    LongTon,
+    AtomicMassUnit,
+    SolarMass
+);
+
+// Optional cross-unit operator support (`==`, `<`, etc.).
+#[cfg(feature = "cross-unit-ops")]
+crate::impl_unit_cross_unit_ops!(
     Gram,
     Yoctogram,
     Zeptogram,

--- a/qtty-core/src/units/power.rs
+++ b/qtty-core/src/units/power.rs
@@ -111,8 +111,37 @@ pub type SolarLuminosities = Quantity<SolarLuminosity>;
 /// One solar luminosity.
 pub const L_SUN: SolarLuminosities = SolarLuminosities::new(1.0);
 
-// Generate all bidirectional From implementations between power units
-crate::impl_unit_conversions!(
+// Generate all bidirectional From implementations between power units.
+crate::impl_unit_from_conversions!(
+    Watt,
+    Yoctowatt,
+    Zeptowatt,
+    Attowatt,
+    Femtowatt,
+    Picowatt,
+    Nanowatt,
+    Microwatt,
+    Milliwatt,
+    Deciwatt,
+    Decawatt,
+    Hectowatt,
+    Kilowatt,
+    Megawatt,
+    Gigawatt,
+    Terawatt,
+    Petawatt,
+    Exawatt,
+    Zettawatt,
+    Yottawatt,
+    ErgPerSecond,
+    HorsepowerMetric,
+    HorsepowerElectric,
+    SolarLuminosity
+);
+
+// Optional cross-unit operator support (`==`, `<`, etc.).
+#[cfg(feature = "cross-unit-ops")]
+crate::impl_unit_cross_unit_ops!(
     Watt,
     Yoctowatt,
     Zeptowatt,

--- a/qtty-core/tests/core.rs
+++ b/qtty-core/tests/core.rs
@@ -578,6 +578,7 @@ fn cross_unit_cmp_method() {
 }
 
 #[test]
+#[cfg(feature = "cross-unit-ops")]
 fn cross_unit_operators_via_macro() {
     use qtty_core::units::length::{Kilometer, Meter};
 
@@ -599,6 +600,7 @@ fn cross_unit_operators_via_macro() {
 }
 
 #[test]
+#[cfg(feature = "cross-unit-ops")]
 fn cross_unit_operators_f32() {
     use qtty_core::units::length::{Kilometer, Meter};
 
@@ -610,6 +612,7 @@ fn cross_unit_operators_f32() {
 }
 
 #[test]
+#[cfg(feature = "cross-unit-ops")]
 fn cross_unit_nan_comparison() {
     use qtty_core::units::length::{Kilometer, Meter};
 

--- a/qtty-core/tests/no_cross_unit_ops.rs
+++ b/qtty-core/tests/no_cross_unit_ops.rs
@@ -1,0 +1,35 @@
+#![cfg(not(feature = "cross-unit-ops"))]
+
+use core::cmp::Ordering;
+use qtty_core::length::{Kilometer, Kilometers, Meter, Meters};
+use qtty_core::Quantity;
+
+#[test]
+fn from_and_to_still_work_without_cross_unit_ops() {
+    let km = Kilometers::new(1.25);
+
+    let m_via_to: Quantity<Meter> = km.to();
+    assert!((m_via_to.value() - 1250.0).abs() < 1e-12);
+
+    let m_via_from: Quantity<Meter> = km.into();
+    assert!((m_via_from.value() - 1250.0).abs() < 1e-12);
+
+    let km_roundtrip: Quantity<Kilometer> = m_via_from.into();
+    assert!((km_roundtrip.value() - 1.25).abs() < 1e-12);
+}
+
+#[test]
+fn eq_unit_and_cmp_unit_replace_cross_unit_operators() {
+    let km = Kilometers::new(2.0);
+    let m_less = Meters::new(1_500.0);
+    let m_eq = Meters::new(2_000.0);
+    let m_more = Meters::new(2_500.0);
+
+    assert!(!km.eq_unit(&m_less));
+    assert!(km.eq_unit(&m_eq));
+    assert!(!km.eq_unit(&m_more));
+
+    assert_eq!(km.cmp_unit(&m_less), Some(Ordering::Greater));
+    assert_eq!(km.cmp_unit(&m_eq), Some(Ordering::Equal));
+    assert_eq!(km.cmp_unit(&m_more), Some(Ordering::Less));
+}

--- a/qtty/Cargo.toml
+++ b/qtty/Cargo.toml
@@ -12,9 +12,10 @@ readme = "README.md"
 documentation = "https://docs.rs/qtty"
 
 [features]
-default = ["std"]
+default = ["std", "cross-unit-ops"]
 alloc = []
 std = ["alloc", "qtty-core/std"]
+cross-unit-ops = ["qtty-core/cross-unit-ops"]
 serde = ["qtty-core/serde"]
 
 # Scalar type support

--- a/qtty/README.md
+++ b/qtty/README.md
@@ -68,6 +68,7 @@ assert!((v.value() - 10.0).abs() < 1e-12);
 ## Feature flags
 
 - `std` (default): enables `std` support in `qtty-core`.
+- `cross-unit-ops` (default): enables direct cross-unit comparison operators (`==`, `<`, etc.) for built-in units.
 - `alloc`: enables heap-backed helpers (including `qtty::qtty_vec!(vec ...)`) in `no_std`.
 - `serde`: serializes/deserializes `Quantity<U>` as bare `f64` values (unit is encoded by the type).
 - `pyo3`: enables PyO3 conversions so `Quantity<U>` types convert to/from Python `float` and can be used

--- a/qtty/src/lib.rs
+++ b/qtty/src/lib.rs
@@ -100,6 +100,7 @@
 //! # Feature flags
 //!
 //! - `std` (default): enables `std` support in `qtty-core`.
+//! - `cross-unit-ops` (default): enables direct cross-unit comparison operators (`==`, `<`, etc.) for built-in units.
 //! - `alloc`: enables heap-backed helpers (like `qtty_vec!(vec ...)`) in `no_std` builds.
 //! - `serde`: enables `serde` support for `Quantity<U>`; serialization is the raw `f64` value only.
 //! - `scalar-decimal`: enables `rust_decimal::Decimal` as a scalar type.


### PR DESCRIPTION
This pull request introduces a new `cross-unit-ops` feature to both the `qtty-core` and `qtty` crates, allowing users to optionally enable or disable direct cross-unit comparison operators (such as `==`, `<`, etc.) for built-in units. The feature is enabled by default, but can be disabled for reduced builds, which reduces trait implementation bloat. The implementation splits unit conversion macros from comparison operator macros, updates documentation, and adds targeted CI and tests to validate behavior in both modes.

Feature introduction and configuration:

* Added the new `cross-unit-ops` feature to `qtty-core` and `qtty`, enabled by default, to gate generation of direct cross-unit comparison operator implementations. (`qtty-core/Cargo.toml`, `qtty/Cargo.toml`, [[1]](diffhunk://#diff-555d817c8f3c9bc108e017bc1d0e90547c588e1a3c85175ba3c36ce348992c1eL15-R17) [[2]](diffhunk://#diff-fd4633112fef7ae503580ab415eaf5487a1dcca7a9574ff61711f1072a9bde1cL15-R18)
* Updated documentation and README files to describe the new feature and its default state, including compile-time benchmarking instructions. (`qtty-core/README.md`, `qtty/README.md`, `README.md`, [[1]](diffhunk://#diff-ee13829eeb0dbc7d0a07cebc2612ff801bc42cad57c6d141a040be4f75c0da8dR79-R91) [[2]](diffhunk://#diff-fd71b990cab66dac7b021e68528d3ba85e110223f9d1378d50b05f811e84fcaeR71) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R51)

Macro and codebase refactoring:

* Split the unit conversion macro into `impl_unit_from_conversions!` (for `From` conversions) and `impl_unit_cross_unit_ops!` (for comparison operators), allowing selective generation based on the `cross-unit-ops` feature. (`qtty-core/src/macros.rs`, [[1]](diffhunk://#diff-3b9cbdfbac01861f57e68679c3883638d104b3dd4045ab17bc67e2f1c56f4b85L3-R5) [[2]](diffhunk://#diff-3b9cbdfbac01861f57e68679c3883638d104b3dd4045ab17bc67e2f1c56f4b85R24-R43) [[3]](diffhunk://#diff-3b9cbdfbac01861f57e68679c3883638d104b3dd4045ab17bc67e2f1c56f4b85L63-R91)
* Refactored unit modules (`length.rs`, `mass.rs`, `power.rs`, `angular.rs`) to use the new macros and conditionally generate operator implementations only if the feature is enabled. [[1]](diffhunk://#diff-f3362aab4c302a526860c25261f2d39f80b33f37e5e571a8e30091b4b109bdd4L558-R615) [[2]](diffhunk://#diff-0106246588bc26b62711e70d3b996aa97199644ef3a3cb1c50ec9802ca5a2692L197-R234) [[3]](diffhunk://#diff-8951c2f0120de9728164d7baa79d246b5b2ad976ebfd5e68bf9108259a2b4ecbL114-R144) [[4]](diffhunk://#diff-4eb6c4c249b0543a96dc33329a89e4f9e15849801b876d91664d78f29da67dd5L401-R417)

Testing and CI enhancements:

* Added new tests and a targeted CI job (`No Cross-Unit Ops`) to validate conversions and ensure direct cross-unit operators are disabled when the feature is off, while `eq_unit` and `cmp_unit` remain available. (`qtty-core/tests/no_cross_unit_ops.rs`, `.github/workflows/ci.yml`, [[1]](diffhunk://#diff-8120c8c3b265a72f66eab1401db83136f738a3656c6a4eedcc5f0ba24ce7888dR1-R35) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR59-R94)
* Updated existing tests to conditionally run cross-unit operator checks only when the feature is enabled. (`qtty-core/tests/core.rs`, [[1]](diffhunk://#diff-953609e35ff0ad3dc9fda802d6031d70f25217f22e48df1561e9f299ff57a226R581) [[2]](diffhunk://#diff-953609e35ff0ad3dc9fda802d6031d70f25217f22e48df1561e9f299ff57a226R603) [[3]](diffhunk://#diff-953609e35ff0ad3dc9fda802d6031d70f25217f22e48df1561e9f299ff57a226R615)

Changelog and documentation updates:

* Documented the new feature, macro refactor, CI profile, and reduced implementation bloat in the changelog and crate-level docs. (`CHANGELOG.md`, `qtty-core/src/lib.rs`, `qtty/src/lib.rs`, [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR12-R22) [[2]](diffhunk://#diff-98520a8163976ce5aeb2ad25dfaec18431f15a372a7d887cf2aa18ce03ab9598R63) [[3]](diffhunk://#diff-da07603ed892a06c9a1cab77df3ce0ed65d7f0b1b7b8b3850de06cb54c015001R103)