### PR TITLE
audit: scientific accuracy, precision, completeness & maintainability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,38 @@ jobs:
       - run: cargo test --all-targets
       - run: cargo test --doc
 
+  feature-matrix:
+    name: Feature Matrix
+    runs-on: ubuntu-latest
+    # Exercise cross-feature bridge code paths that only compile when specific
+    # feature *pairs* are enabled.  The coverage job runs --all-features but
+    # does not prove that each intermediate combination is sound on its own.
+    strategy:
+      fail-fast: false
+      matrix:
+        features:
+          # Pairs that activate astro cross-feature bridges
+          - "astro,julian-time"
+          - "astro,customary"
+          - "astro,navigation"
+          - "astro,fundamental-physics"
+          - "astro,land-area"
+          # Pairs that activate non-astro cross-feature bridges
+          - "customary,navigation"
+          - "customary,fundamental-physics"
+          - "navigation,fundamental-physics"
+          - "julian-time,customary"
+          # Triple combination to catch three-way interaction
+          - "astro,customary,cross-unit-ops"
+          - "astro,navigation,cross-unit-ops"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Check feature combination ${{ matrix.features }}
+        run: cargo check -p qtty-core --no-default-features --features "std,${{ matrix.features }}"
+      - name: Test feature combination ${{ matrix.features }}
+        run: cargo test -p qtty-core --no-default-features --features "std,${{ matrix.features }}"
+
   no-cross-unit-ops:
     name: No Cross-Unit Ops
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,14 +58,28 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and
 - 18 regression tests in `qtty-core/tests/audit_regressions.rs` covering
   cross-unit comparison symmetry, integer `abs()` boundary behaviour, and
   lossy/checked conversion semantics.
+- **`MulAssign<S>`** for `Quantity<U, S>` — in-place scalar multiplication
+  (`q *= 2.0`), symmetric with the pre-existing `DivAssign<S>`.
+- **`Rem<Quantity<U, S>>`** for same-unit remainder — `5 m % 3 m == 2 m`,
+  complementing the pre-existing scalar `Rem<S>`.
+- **`DAYS_PER_GREGORIAN_YEAR`** named constant (`qtty-core::time`) — replaces
+  the four repeated `365.242_5` literals in `Year`/`Decade`/`Century`/`Millennium`
+  ratio expressions.
 
 ### Removed
 - **`qtty-ffi` `units.csv`** — hardcoded ratio/symbol data removed; metadata is now derived from qtty-core trait constants so divergence is impossible at compile time.
 - **`qtty-ffi` deprecated helper functions** — `meters_into_ffi`, `try_into_meters`, `kilometers_into_ffi`, `try_into_kilometers`, `seconds_into_ffi`, `try_into_seconds`, `minutes_into_ffi`, `try_into_minutes`, `hours_into_ffi`, `try_into_hours`, `days_into_ffi`, `try_into_days`, `radians_into_ffi`, `try_into_radians`, `degrees_into_ffi`, `try_into_degrees` (all deprecated since 0.5.1) have been removed. Use `From`/`TryFrom` directly (`qty.into()`, `qty.try_into()`).
 - Removed the `scalar-decimal` feature and `rust_decimal` scalar support from `qtty-core` and the `qtty` facade crate.
 - **Breaking:** Removed the public `Simplify` trait and `.simplify()` method from `qtty-core` and the `qtty` facade crate; unit arithmetic now resolves these cases at compile time.
+- **Breaking:** Removed the deprecated `frequency` alias modules from `qtty-core` and `qtty`. Use `angular_rate` for `Angular / Time` quantities.
+- **Breaking:** Removed deprecated `Quantity<Unitless>::asin()`, `acos()`, and `atan()` scalar-returning methods. Use `asin_angle()`, `acos_angle()`, and `atan_angle()` instead.
 
 ### Changed
+- **CODATA 2018 → 2022** (`fundamental-physics`) — Updated Bohr radius,
+  classical electron radius, and electron reduced Compton wavelength to the
+  CODATA 2022 recommended values. Planck length and atomic mass unit are
+  unchanged (identical in both adjustments). Affected constants and their
+  tests updated accordingly.
 - **Internal: inventory macros are now the canonical unit lists** — every
   always-available unit family in `qtty-core` (`angular`, `length`, `time`,
   `mass`, `power`, `area`, `volume`, `acceleration`, `force`, `energy`) and the
@@ -108,6 +122,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and
   `b == a` after a floating-point round-trip.
 
 ### Fixed
+- **`f32` `to_const` precision** — ratio conversion for `f32`-backed quantities
+  now performs the `U::RATIO / T::RATIO` division in `f64` before casting to
+  `f32`, matching the `f64` code path and avoiding doubled rounding error from
+  two independent `as f32` casts.
 - Cleaned up stale `scalar-decimal` cfg gates, tests, and documentation left behind by the Decimal removal so current builds no longer emit `unexpected_cfgs` warnings.
 - Made `Quantity::mean()` overflow-safe for integer-backed quantities by avoiding addition before division.
 - Made `Degrees::from_dms()` and `HourAngles::from_hms()` safe for `i32::MIN` inputs by avoiding signed integer negation before widening.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 > **Strongly typed physical quantities for Rust, with astronomy-friendly units and zero-cost dimensional safety.**
 
 `qtty` keeps units in the type system instead of in comments or conventions. Length, time, angle, mass, power, area,
-volume, velocity, frequency, and unitless ratios are modeled as typed quantities, so invalid operations fail at
+volume, velocity, angular rate, and unitless ratios are modeled as typed quantities, so invalid operations fail at
 compile time while valid conversions stay explicit and cheap.
 
 ---
@@ -51,7 +51,7 @@ compile time while valid conversions stay explicit and cheap.
 | **Typed Quantities** | `Quantity<U, S>` keeps the unit `U` and scalar `S` at the type level, preventing invalid arithmetic across dimensions. |
 | **Explicit Conversion** | Convert with `.to::<TargetUnit>()`, or use `.to_lossy()` for integer-backed quantities. |
 | **Dimensional Arithmetic** | Multiplication and division compose dimensions at compile time: `Length * Length -> Area`, `Length / Time -> Velocity`, and more. |
-| **Broad Unit Catalog** | Built-in modules cover angular, time, length, mass, power, area, volume, velocity, frequency, and unitless quantities. |
+| **Broad Unit Catalog** | Built-in modules cover angular, time, length, mass, power, area, volume, velocity, angular-rate, and unitless quantities. |
 | **Astronomy-Friendly Units** | Includes `AstronomicalUnit`, `LightYear`, `Parsec`, `SolarMass`, `SolarLuminosity`, sidereal time units, and related helpers. |
 | **Multiple Scalar Families** | Use `f64`, `f32`, signed integers, and optional decimal/rational scalars depending on your precision model. |
 | **Interop Options** | Optional `serde`, `ffi`, `pyo3`, `diesel`, `tiberius`, plus a separate `qtty-ffi` crate for C-compatible consumers. |

--- a/qtty-core/src/lib.rs
+++ b/qtty-core/src/lib.rs
@@ -171,10 +171,10 @@ pub mod units;
 
 pub use units::acceleration;
 pub use units::angular;
+pub use units::angular_rate;
 pub use units::area;
 pub use units::energy;
 pub use units::force;
-pub use units::frequency;
 pub use units::length;
 pub use units::mass;
 pub use units::power;
@@ -644,6 +644,67 @@ mod tests {
     // ─────────────────────────────────────────────────────────────────────────────
     // Serde tests
     // ─────────────────────────────────────────────────────────────────────────────
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // to_lossy / checked_to_lossy regression: large integer same-unit corruption
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn to_lossy_same_unit_large_i64_is_stable() {
+        // Before the fix, the f64 round-trip corrupted values near i64::MAX:
+        //   (i64::MAX - 1) as f64 rounds up to i64::MAX as f64,
+        //   then back to i64::MAX — a silent mutation.
+        let q = Quantity::<TestUnit, i64>::new(i64::MAX - 1);
+        let result: Quantity<TestUnit, i64> = q.to_lossy();
+        assert_eq!(result.value(), i64::MAX - 1);
+    }
+
+    #[test]
+    fn checked_to_lossy_same_unit_large_i64_is_stable() {
+        // The "checked" path must not report success on a mutated value.
+        let q = Quantity::<TestUnit, i64>::new(i64::MAX - 1);
+        let result: Option<Quantity<TestUnit, i64>> = q.checked_to_lossy();
+        assert_eq!(result.map(|q| q.value()), Some(i64::MAX - 1));
+    }
+
+    #[test]
+    fn checked_to_lossy_cross_unit_overflow_returns_none() {
+        // 1 km in i8 meters = 1000, which overflows i8.
+        use crate::length::{Kilometer, Meter};
+        let km = Quantity::<Kilometer, i8>::new(1);
+        assert_eq!(km.checked_to_lossy::<Meter>(), None);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // mean regression: same-sign infinities must not produce NaN
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn mean_positive_infinity_stays_infinite() {
+        // The split-half overflow-avoidance path computed ∞ − ∞ = NaN.
+        // The midpoint of two identical positive infinities must be +∞.
+        let inf = TU::INFINITY;
+        assert!(inf.mean(inf).value().is_infinite());
+        assert!(inf.mean(inf).value() > 0.0);
+    }
+
+    #[test]
+    fn mean_negative_infinity_stays_infinite() {
+        let neg_inf = TU::NEG_INFINITY;
+        assert!(neg_inf.mean(neg_inf).value().is_infinite());
+        assert!(neg_inf.mean(neg_inf).value() < 0.0);
+    }
+
+    #[test]
+    fn mean_finite_values_unaffected() {
+        assert_eq!(TU::new(10.0).mean(TU::new(14.0)).value(), 12.0);
+        assert_eq!(
+            TU::new(i64::MAX as f64)
+                .mean(TU::new(i64::MAX as f64))
+                .value(),
+            i64::MAX as f64
+        );
+    }
 
     #[cfg(feature = "serde")]
     mod serde_tests {

--- a/qtty-core/src/quantity.rs
+++ b/qtty-core/src/quantity.rs
@@ -159,6 +159,14 @@ impl<U: Unit, S: Scalar> Quantity<U, S> {
         let two = S::ONE + S::ONE;
         let a = self.0;
         let b = other.0;
+        // Equal operands: the midpoint is the operand itself.
+        // This also short-circuits same-sign infinities (e.g. +∞.mean(+∞)):
+        // the split-half path below computes ∞ − ∞ = NaN for those cases,
+        // which would violate the IEEE-754 expectation that the midpoint of
+        // two identical infinities stays infinite.
+        if a == b {
+            return Self::new(a);
+        }
         // When both values have the same sign, their sum may overflow.
         // Use a split-half formula that is safe for same-sign operands.
         // When signs differ, the direct sum never overflows (for integers
@@ -253,6 +261,17 @@ impl<U: Unit, S: Real> Quantity<U, S> {
     }
 
     /// Converts this quantity to another unit of the same dimension.
+    ///
+    /// The conversion multiplies the scalar value by `U::RATIO / T::RATIO`.
+    /// Because [`Unit::RATIO`] is always an `f64`, this ratio is computed in
+    /// `f64` and then cast back to `S` via [`Scalar::from_f64`].  For
+    /// floating-point scalars (`f64`, `f32`) the precision loss is negligible.
+    /// For **exact scalar types** (`Rational64`, integers) the cast is lossy:
+    /// the numeric value will be an `f64`-rounded approximation of the true
+    /// rational ratio.  See [`Exact`] for the explicit trade-off documentation.
+    ///
+    /// If you need unit conversion without the `f64` round-trip, store values
+    /// in the target unit from the start rather than converting after the fact.
     ///
     /// # Example
     ///
@@ -390,8 +409,15 @@ impl<U: Unit, S: Exact> Quantity<U, S> {
     /// ```
     #[inline]
     pub fn to_lossy<T: Unit<Dim = U::Dim>>(self) -> Quantity<T, S> {
-        let value_f64 = self.0.to_f64_approx();
         let ratio = U::RATIO / T::RATIO;
+        // Same-ratio fast path: skip the f64 round-trip entirely.
+        // Without this, large integer values (e.g. near i64::MAX) would be
+        // corrupted even for identity conversions because f64 cannot represent
+        // them exactly.
+        if ratio == 1.0 {
+            return Quantity::<T, S>::new(self.0);
+        }
+        let value_f64 = self.0.to_f64_approx();
         Quantity::<T, S>::new(S::from_f64_approx(value_f64 * ratio))
     }
 
@@ -417,8 +443,14 @@ impl<U: Unit, S: Exact> Quantity<U, S> {
     /// ```
     #[inline]
     pub fn checked_to_lossy<T: Unit<Dim = U::Dim>>(self) -> Option<Quantity<T, S>> {
-        let value_f64 = self.0.to_f64_approx();
         let ratio = U::RATIO / T::RATIO;
+        // Same-ratio fast path: the value is unchanged, so always in range.
+        // Without this, large integers near i64::MAX would round-trip through
+        // f64 and either return a mutated value or a false None.
+        if ratio == 1.0 {
+            return Some(Quantity::<T, S>::new(self.0));
+        }
+        let value_f64 = self.0.to_f64_approx();
         S::checked_from_f64(value_f64 * ratio).map(Quantity::<T, S>::new)
     }
 }
@@ -518,7 +550,7 @@ impl<U: Unit + Copy> Quantity<U, f32> {
     /// Const conversion to another unit.
     #[inline]
     pub const fn to_const<T: Unit<Dim = U::Dim> + Copy>(self) -> Quantity<T, f32> {
-        Quantity::<T, f32>(self.0 * (U::RATIO as f32 / T::RATIO as f32), PhantomData)
+        Quantity::<T, f32>(self.0 * ((U::RATIO / T::RATIO) as f32), PhantomData)
     }
 
     /// Const min of two quantities.
@@ -640,6 +672,29 @@ impl<U: Unit, S: Scalar> Mul<S> for Quantity<U, S> {
     }
 }
 
+impl<U: Unit, S: Scalar> MulAssign<S> for Quantity<U, S> {
+    /// In-place scalar multiplication.
+    ///
+    /// ```rust
+    /// use qtty_core::length::Meters;
+    ///
+    /// let mut d = Meters::new(3.0);
+    /// d *= 4.0;
+    /// assert_eq!(d.value(), 12.0);
+    /// ```
+    ///
+    /// ```compile_fail
+    /// use qtty_core::length::Meters;
+    ///
+    /// let mut d = Meters::new(3.0);
+    /// d *= Meters::new(4.0);
+    /// ```
+    #[inline]
+    fn mul_assign(&mut self, rhs: S) {
+        self.0 *= rhs;
+    }
+}
+
 impl<U: Unit, S: Scalar> Div<S> for Quantity<U, S> {
     type Output = Self;
     #[inline]
@@ -738,6 +793,15 @@ impl<U: Unit, S: Scalar + Rem<Output = S>> Rem<S> for Quantity<U, S> {
     #[inline]
     fn rem(self, rhs: S) -> Self {
         Self::new(self.0 % rhs)
+    }
+}
+
+// Same-unit remainder: `5 m % 3 m == 2 m`.
+impl<U: Unit, S: Scalar + Rem<Output = S>> Rem for Quantity<U, S> {
+    type Output = Self;
+    #[inline]
+    fn rem(self, rhs: Self) -> Self {
+        Self::new(self.0 % rhs.0)
     }
 }
 
@@ -849,48 +913,5 @@ impl<S: Transcendental> Quantity<Unitless, S> {
     #[inline]
     pub fn atan_angle(&self) -> Quantity<crate::units::angular::Radian, S> {
         Quantity::new(self.0.atan())
-    }
-
-    /// Arc sine of a unitless quantity (returns raw scalar).
-    ///
-    /// # Deprecation
-    ///
-    /// Use [`asin_angle`](Self::asin_angle) instead, which returns a typed
-    /// `Quantity<Radian, S>`. This method will be removed in a future release.
-    #[deprecated(
-        since = "0.2.0",
-        note = "use `asin_angle()` which returns Quantity<Radian, S>"
-    )]
-    #[inline]
-    pub fn asin(&self) -> S {
-        self.0.asin()
-    }
-
-    /// Arc cosine of a unitless quantity (returns raw scalar).
-    ///
-    /// # Deprecation
-    ///
-    /// Use [`acos_angle`](Self::acos_angle) instead.
-    #[deprecated(
-        since = "0.2.0",
-        note = "use `acos_angle()` which returns Quantity<Radian, S>"
-    )]
-    #[inline]
-    pub fn acos(&self) -> S {
-        self.0.acos()
-    }
-
-    /// Arc tangent of a unitless quantity (returns raw scalar).
-    ///
-    /// # Deprecation
-    ///
-    /// Use [`atan_angle`](Self::atan_angle) instead.
-    #[deprecated(
-        since = "0.2.0",
-        note = "use `atan_angle()` which returns Quantity<Radian, S>"
-    )]
-    #[inline]
-    pub fn atan(&self) -> S {
-        self.0.atan()
     }
 }

--- a/qtty-core/src/scalar.rs
+++ b/qtty-core/src/scalar.rs
@@ -1462,15 +1462,26 @@ macro_rules! impl_scalar_for_signed_int {
                 if !value.is_finite() {
                     return None;
                 }
-                let converted = value as Self;
-                // Detect saturation: if the round-trip difference is ≥ 1.0,
-                // the value was outside the representable range.
-                let round_trip = converted as f64;
-                if (round_trip - value).abs() >= 1.0 {
-                    None
-                } else {
-                    Some(converted)
+                // Explicit bounds check instead of a round-trip comparison.
+                // The round-trip approach silently accepts saturated casts when
+                // f64 spacing exceeds 1 near the type extremes (i64/i128): for
+                // example, (i64::MAX - 1) as f64 rounds up to the same bit
+                // pattern as i64::MAX as f64, so the round-trip difference is
+                // 0 even though the cast saturated.
+                //
+                // * MIN is always −2^(n−1), exactly representable in f64.
+                // * For narrow types (i8/i16/i32) MAX is exact in f64, so
+                //   F_MAX_EXCL = MAX as f64 + 1.0 is the first integer above
+                //   the range.
+                // * For wide types (i64/i128) MAX rounds up in f64 (to 2^63
+                //   or 2^127), so adding 1.0 is a no-op — that rounded-up
+                //   value is itself the correct exclusive upper bound.
+                const F_MIN: f64 = <$t>::MIN as f64;
+                const F_MAX_EXCL: f64 = <$t>::MAX as f64 + 1.0;
+                if !(F_MIN..F_MAX_EXCL).contains(&value) {
+                    return None;
                 }
+                Some(value as Self)
             }
         }
 
@@ -1585,5 +1596,53 @@ mod tests {
 
         // i8
         assert_eq!(i8::from_f64_approx(100.0), 100);
+    }
+
+    // ── checked_from_f64 regression: large integer saturation ─────────────────
+    //
+    // Previously the round-trip check ((converted as f64 - value).abs() < 1.0)
+    // could not detect saturation for i64/i128 values near MAX because f64
+    // spacing there exceeds 1, so the saturated cast and the input f64 were
+    // indistinguishable.
+
+    #[test]
+    fn checked_from_f64_i8_boundaries() {
+        assert_eq!(i8::checked_from_f64(127.0), Some(127));
+        assert_eq!(i8::checked_from_f64(127.9), Some(127)); // truncated, in range
+        assert_eq!(i8::checked_from_f64(128.0), None);
+        assert_eq!(i8::checked_from_f64(-128.0), Some(-128));
+        assert_eq!(i8::checked_from_f64(-128.9), None);
+        assert_eq!(i8::checked_from_f64(f64::INFINITY), None);
+        assert_eq!(i8::checked_from_f64(f64::NAN), None);
+    }
+
+    #[test]
+    fn checked_from_f64_i32_boundaries() {
+        assert_eq!(i32::checked_from_f64(2147483647.0), Some(i32::MAX));
+        assert_eq!(i32::checked_from_f64(2147483648.0), None);
+        assert_eq!(i32::checked_from_f64(-2147483648.0), Some(i32::MIN));
+        assert_eq!(i32::checked_from_f64(-2147483649.0), None);
+    }
+
+    #[test]
+    fn checked_from_f64_i64_no_false_success_near_max() {
+        // (i64::MAX - 1) rounds up to i64::MAX as f64 (= 2^63), which then
+        // saturates back to i64::MAX on cast.  The old round-trip check
+        // accepted this as Some(i64::MAX), silently mutating the value.
+        // The fixed bounds check must return None for any f64 >= 2^63.
+        let near_max_f64 = (i64::MAX - 1) as f64; // rounds up to 2^63
+        assert_eq!(i64::checked_from_f64(near_max_f64), None);
+        assert_eq!(i64::checked_from_f64(i64::MAX as f64), None); // 2^63, out of range
+
+        // Values that fit should still succeed.
+        // Largest f64 strictly below 2^63 is 2^63 - 1024.
+        let safe_max_f64 = 9_223_372_036_854_774_784.0_f64; // 2^63 - 1024
+        assert_eq!(
+            i64::checked_from_f64(safe_max_f64),
+            Some(9_223_372_036_854_774_784_i64)
+        );
+
+        // MIN is exactly representable.
+        assert_eq!(i64::checked_from_f64(i64::MIN as f64), Some(i64::MIN));
     }
 }

--- a/qtty-core/src/unit.rs
+++ b/qtty-core/src/unit.rs
@@ -23,6 +23,17 @@ use core::marker::PhantomData;
 ///
 /// - Implementations should be zero-sized marker types (this crate's built-in units are unit structs with no fields).
 /// - `RATIO` should be finite and non-zero.
+///
+/// # Conversion precision
+///
+/// `RATIO` is an `f64`, so converting between units always involves an `f64`
+/// multiplication even when the scalar type is "exact" (e.g. `Rational64` or
+/// an integer). This is a deliberate trade-off: the type-level unit system
+/// remains zero-cost and dimensional analysis is exact, but the *numeric*
+/// conversion factor is limited to `f64` precision. Changing this to, say, a
+/// rational ratio would require a core trait redesign because the ratio is a
+/// compile-time constant and Rust's const generics do not yet support
+/// arbitrary-precision types.
 pub trait Unit: Copy + PartialEq + Debug + 'static {
     /// Unit-to-canonical conversion factor.
     const RATIO: f64;

--- a/qtty-core/src/unit_arithmetic.rs
+++ b/qtty-core/src/unit_arithmetic.rs
@@ -22,9 +22,10 @@
 //! - `A * B → Prod<A, B>`
 //!
 //! Downstream crates can use the exported macros
-//! [`impl_unit_division_pairs!`], [`impl_unit_multiplication_pairs!`], and
-//! [`impl_unit_arithmetic_pairs!`] to register their own custom units into the
-//! same fallback tables.
+//! [`impl_unit_division_pairs!`], [`impl_unit_multiplication_pairs!`],
+//! [`impl_unit_arithmetic_pairs!`], and their `*_between!` variants to
+//! register their own custom units into the same fallback tables without
+//! regenerating built-in/built-in impls.
 
 use crate::dimension::{DimDiv, DimMul, Dimension};
 use crate::unit::{Per, Prod, Unit, Unitless};
@@ -173,6 +174,31 @@ macro_rules! impl_unit_division_pairs {
     };
 }
 
+/// Generates `UnitDiv` impls between every unit in the **extra** group and
+/// every unit in the **base** group, plus all intra-extra pairs.
+///
+/// This does **not** regenerate intra-base pairs, which avoids conflicting with
+/// existing registrations for built-in units.
+///
+/// # Example
+///
+/// ```ignore
+/// impl_unit_division_pairs_between!(Meter, Kilometer; Smoot, Furlong);
+/// // Generates:
+/// //   Meter / Smoot, Smoot / Meter
+/// //   Kilometer / Smoot, Smoot / Kilometer
+/// //   Meter / Furlong, Furlong / Meter
+/// //   Kilometer / Furlong, Furlong / Kilometer
+/// //   Smoot / Furlong, Furlong / Smoot
+/// ```
+#[macro_export]
+macro_rules! impl_unit_division_pairs_between {
+    ($($base:ty),+; $($extra:ty),+ $(,)?) => {
+        $crate::__impl_div_pairs_each_extra_to_bases!({$($base),+} $($extra),+);
+        $crate::impl_unit_division_pairs!($($extra),+);
+    };
+}
+
 /// Generates `UnitMul` impls for all ordered pairs of units, **including**
 /// self-pairs (`A * A`).
 ///
@@ -238,6 +264,19 @@ macro_rules! impl_unit_multiplication_pairs {
     };
 }
 
+/// Generates `UnitMul` impls between every unit in the **extra** group and
+/// every unit in the **base** group, plus all intra-extra pairs.
+///
+/// This does **not** regenerate intra-base pairs, which avoids conflicting with
+/// existing registrations for built-in units.
+#[macro_export]
+macro_rules! impl_unit_multiplication_pairs_between {
+    ($($base:ty),+; $($extra:ty),+ $(,)?) => {
+        $crate::__impl_mul_pairs_each_extra_to_bases!({$($base),+} $($extra),+);
+        $crate::impl_unit_multiplication_pairs!($($extra),+);
+    };
+}
+
 /// Convenience macro that generates both division and multiplication pair
 /// tables for a set of units.
 ///
@@ -248,6 +287,115 @@ macro_rules! impl_unit_arithmetic_pairs {
     ($($unit:ty),+ $(,)?) => {
         $crate::impl_unit_division_pairs!($($unit),+);
         $crate::impl_unit_multiplication_pairs!($($unit),+);
+    };
+}
+
+/// Convenience macro that generates both division and multiplication impls
+/// between an existing **base** group and a new **extra** group.
+///
+/// Equivalent to calling [`impl_unit_division_pairs_between!`] and
+/// [`impl_unit_multiplication_pairs_between!`] with the same arguments.
+#[macro_export]
+macro_rules! impl_unit_arithmetic_pairs_between {
+    ($($base:ty),+; $($extra:ty),+ $(,)?) => {
+        $crate::impl_unit_division_pairs_between!($($base),+; $($extra),+);
+        $crate::impl_unit_multiplication_pairs_between!($($base),+; $($extra),+);
+    };
+}
+
+/// Hidden helper for [`impl_unit_division_pairs_between!`].
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __impl_div_pairs_each_extra_to_bases {
+    // Base case: single extra remaining.
+    ({$($base:ty),+} $extra:ty) => {
+        $(
+            impl $crate::unit_arithmetic::UnitDiv<$extra> for $base
+            where
+                <$base as $crate::Unit>::Dim: $crate::DimDiv<<$extra as $crate::Unit>::Dim>,
+                <<$base as $crate::Unit>::Dim as $crate::DimDiv<<$extra as $crate::Unit>::Dim>>::Output: $crate::Dimension,
+            {
+                type Output = $crate::Per<$base, $extra>;
+            }
+
+            impl $crate::unit_arithmetic::UnitDiv<$base> for $extra
+            where
+                <$extra as $crate::Unit>::Dim: $crate::DimDiv<<$base as $crate::Unit>::Dim>,
+                <<$extra as $crate::Unit>::Dim as $crate::DimDiv<<$base as $crate::Unit>::Dim>>::Output: $crate::Dimension,
+            {
+                type Output = $crate::Per<$extra, $base>;
+            }
+        )+
+    };
+    // Recursive case: peel the first extra, recurse on the rest.
+    ({$($base:ty),+} $first:ty, $($rest:ty),+) => {
+        $(
+            impl $crate::unit_arithmetic::UnitDiv<$first> for $base
+            where
+                <$base as $crate::Unit>::Dim: $crate::DimDiv<<$first as $crate::Unit>::Dim>,
+                <<$base as $crate::Unit>::Dim as $crate::DimDiv<<$first as $crate::Unit>::Dim>>::Output: $crate::Dimension,
+            {
+                type Output = $crate::Per<$base, $first>;
+            }
+
+            impl $crate::unit_arithmetic::UnitDiv<$base> for $first
+            where
+                <$first as $crate::Unit>::Dim: $crate::DimDiv<<$base as $crate::Unit>::Dim>,
+                <<$first as $crate::Unit>::Dim as $crate::DimDiv<<$base as $crate::Unit>::Dim>>::Output: $crate::Dimension,
+            {
+                type Output = $crate::Per<$first, $base>;
+            }
+        )+
+
+        $crate::__impl_div_pairs_each_extra_to_bases!({$($base),+} $($rest),+);
+    };
+}
+
+/// Hidden helper for [`impl_unit_multiplication_pairs_between!`].
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __impl_mul_pairs_each_extra_to_bases {
+    // Base case: single extra remaining.
+    ({$($base:ty),+} $extra:ty) => {
+        $(
+            impl $crate::unit_arithmetic::UnitMul<$extra> for $base
+            where
+                <$base as $crate::Unit>::Dim: $crate::DimMul<<$extra as $crate::Unit>::Dim>,
+                <<$base as $crate::Unit>::Dim as $crate::DimMul<<$extra as $crate::Unit>::Dim>>::Output: $crate::Dimension,
+            {
+                type Output = $crate::Prod<$base, $extra>;
+            }
+
+            impl $crate::unit_arithmetic::UnitMul<$base> for $extra
+            where
+                <$extra as $crate::Unit>::Dim: $crate::DimMul<<$base as $crate::Unit>::Dim>,
+                <<$extra as $crate::Unit>::Dim as $crate::DimMul<<$base as $crate::Unit>::Dim>>::Output: $crate::Dimension,
+            {
+                type Output = $crate::Prod<$extra, $base>;
+            }
+        )+
+    };
+    // Recursive case: peel the first extra, recurse on the rest.
+    ({$($base:ty),+} $first:ty, $($rest:ty),+) => {
+        $(
+            impl $crate::unit_arithmetic::UnitMul<$first> for $base
+            where
+                <$base as $crate::Unit>::Dim: $crate::DimMul<<$first as $crate::Unit>::Dim>,
+                <<$base as $crate::Unit>::Dim as $crate::DimMul<<$first as $crate::Unit>::Dim>>::Output: $crate::Dimension,
+            {
+                type Output = $crate::Prod<$base, $first>;
+            }
+
+            impl $crate::unit_arithmetic::UnitMul<$base> for $first
+            where
+                <$first as $crate::Unit>::Dim: $crate::DimMul<<$base as $crate::Unit>::Dim>,
+                <<$first as $crate::Unit>::Dim as $crate::DimMul<<$base as $crate::Unit>::Dim>>::Output: $crate::Dimension,
+            {
+                type Output = $crate::Prod<$first, $base>;
+            }
+        )+
+
+        $crate::__impl_mul_pairs_each_extra_to_bases!({$($base),+} $($rest),+);
     };
 }
 
@@ -289,63 +437,7 @@ macro_rules! register_builtin_units_extend {
         // Mark each extension type as built-in.
         $(impl BuiltinUnit for $extra {})+
 
-        // Intra-extra pairs.
-        impl_unit_division_pairs!($($extra),+);
-
-        // Cross base × extra pairs (recursive to avoid repetition-count mismatch).
-        __impl_div_pairs_each_extra_to_bases!({$($base),+} $($extra),+);
-    };
-}
-
-/// Recursive helper: iterate over extras one at a time, emitting cross-division
-/// impls with the full base list each time.
-#[cfg(any(
-    feature = "astro",
-    feature = "julian-time",
-    feature = "customary",
-    feature = "navigation",
-    feature = "fundamental-physics",
-    feature = "land-area",
-))]
-macro_rules! __impl_div_pairs_each_extra_to_bases {
-    // Base case: single extra remaining.
-    ({$($base:ty),+} $extra:ty) => {
-        $(
-            impl $crate::unit_arithmetic::UnitDiv<$extra> for $base
-            where
-                <$base as $crate::Unit>::Dim: $crate::DimDiv<<$extra as $crate::Unit>::Dim>,
-                <<$base as $crate::Unit>::Dim as $crate::DimDiv<<$extra as $crate::Unit>::Dim>>::Output: $crate::Dimension,
-            {
-                type Output = $crate::Per<$base, $extra>;
-            }
-            impl $crate::unit_arithmetic::UnitDiv<$base> for $extra
-            where
-                <$extra as $crate::Unit>::Dim: $crate::DimDiv<<$base as $crate::Unit>::Dim>,
-                <<$extra as $crate::Unit>::Dim as $crate::DimDiv<<$base as $crate::Unit>::Dim>>::Output: $crate::Dimension,
-            {
-                type Output = $crate::Per<$extra, $base>;
-            }
-        )+
-    };
-    // Recursive case: peel the first extra, recurse on the rest.
-    ({$($base:ty),+} $first:ty, $($rest:ty),+) => {
-        $(
-            impl $crate::unit_arithmetic::UnitDiv<$first> for $base
-            where
-                <$base as $crate::Unit>::Dim: $crate::DimDiv<<$first as $crate::Unit>::Dim>,
-                <<$base as $crate::Unit>::Dim as $crate::DimDiv<<$first as $crate::Unit>::Dim>>::Output: $crate::Dimension,
-            {
-                type Output = $crate::Per<$base, $first>;
-            }
-            impl $crate::unit_arithmetic::UnitDiv<$base> for $first
-            where
-                <$first as $crate::Unit>::Dim: $crate::DimDiv<<$base as $crate::Unit>::Dim>,
-                <<$first as $crate::Unit>::Dim as $crate::DimDiv<<$base as $crate::Unit>::Dim>>::Output: $crate::Dimension,
-            {
-                type Output = $crate::Per<$first, $base>;
-            }
-        )+
-        __impl_div_pairs_each_extra_to_bases!({$($base),+} $($rest),+);
+        $crate::impl_unit_division_pairs_between!($($base),+; $($extra),+);
     };
 }
 
@@ -633,3 +725,313 @@ macro_rules! extend_with_land_area {
 }
 #[cfg(feature = "land-area")]
 with_base_units!(extend_with_land_area);
+
+// ── Per-feature "as-base" UnitDiv helpers ─────────────────────────────────────
+//
+// Each macro below holds ONE optional feature's complete unit list.  When two
+// optional features are both enabled the macro for the *larger* family is
+// invoked with the *smaller* family's units as arguments, so each unit list
+// lives in exactly one place rather than being copy-pasted into every pairing.
+//
+// To add a new optional unit family F:
+//   1. Define `__impl_div_pairs_with_F_as_base!` here with F's full unit list.
+//   2. Add one `#[cfg(all(feature = "F", feature = "X"))]` call per existing
+//      family X, invoking whichever family's macro covers the larger set.
+// Nothing else in this file needs to change.
+
+#[cfg(feature = "astro")]
+macro_rules! __impl_div_pairs_with_astro_as_base {
+    ($($extra:ty),+ $(,)?) => {
+        crate::__impl_div_pairs_each_extra_to_bases!(
+            {
+                crate::units::length::AstronomicalUnit,
+                crate::units::length::LightYear,
+                crate::units::length::Parsec,
+                crate::units::length::Kiloparsec,
+                crate::units::length::Megaparsec,
+                crate::units::length::Gigaparsec,
+                crate::units::length::nominal::SolarRadius,
+                crate::units::length::nominal::SolarDiameter,
+                crate::units::length::nominal::EarthRadius,
+                crate::units::length::nominal::EarthEquatorialRadius,
+                crate::units::length::nominal::EarthPolarRadius,
+                crate::units::length::nominal::JupiterRadius,
+                crate::units::length::nominal::LunarRadius,
+                crate::units::length::nominal::LunarDistance,
+                crate::units::time::SiderealDay,
+                crate::units::time::SynodicMonth,
+                crate::units::time::SiderealYear,
+                crate::units::mass::SolarMass,
+                crate::units::angular::Arcminute,
+                crate::units::angular::Arcsecond,
+                crate::units::angular::MilliArcsecond,
+                crate::units::angular::MicroArcsecond,
+                crate::units::angular::HourAngle,
+                crate::units::power::SolarLuminosity
+            }
+            $($extra),+
+        );
+    };
+}
+
+#[cfg(feature = "customary")]
+macro_rules! __impl_div_pairs_with_customary_as_base {
+    ($($extra:ty),+ $(,)?) => {
+        crate::__impl_div_pairs_each_extra_to_bases!(
+            {
+                crate::units::length::Inch,
+                crate::units::length::Foot,
+                crate::units::length::Yard,
+                crate::units::length::Mile,
+                crate::units::mass::Carat,
+                crate::units::mass::Grain,
+                crate::units::mass::Pound,
+                crate::units::mass::Ounce,
+                crate::units::mass::Stone,
+                crate::units::mass::ShortTon,
+                crate::units::mass::LongTon,
+                crate::units::power::HorsepowerMetric,
+                crate::units::power::HorsepowerElectric,
+                crate::units::area::SquareInch,
+                crate::units::area::SquareFoot,
+                crate::units::area::SquareYard,
+                crate::units::area::SquareMile,
+                crate::units::volume::CubicInch,
+                crate::units::volume::CubicFoot,
+                crate::units::volume::UsGallon,
+                crate::units::volume::UsFluidOunce,
+                crate::units::force::PoundForce,
+                crate::units::energy::Calorie,
+                crate::units::energy::Kilocalorie
+            }
+            $($extra),+
+        );
+    };
+}
+
+#[cfg(feature = "fundamental-physics")]
+macro_rules! __impl_div_pairs_with_fundamental_physics_as_base {
+    ($($extra:ty),+ $(,)?) => {
+        crate::__impl_div_pairs_each_extra_to_bases!(
+            {
+                crate::units::length::BohrRadius,
+                crate::units::length::ClassicalElectronRadius,
+                crate::units::length::PlanckLength,
+                crate::units::length::ElectronReducedComptonWavelength,
+                crate::units::mass::AtomicMassUnit,
+                crate::units::power::ErgPerSecond,
+                crate::units::force::Dyne,
+                crate::units::energy::Erg,
+                crate::units::energy::Electronvolt,
+                crate::units::energy::Kiloelectronvolt,
+                crate::units::energy::Megaelectronvolt
+            }
+            $($extra),+
+        );
+    };
+}
+
+#[cfg(feature = "navigation")]
+macro_rules! __impl_div_pairs_with_navigation_as_base {
+    ($($extra:ty),+ $(,)?) => {
+        crate::__impl_div_pairs_each_extra_to_bases!(
+            {
+                crate::units::length::NauticalMile,
+                crate::units::length::Chain,
+                crate::units::length::Rod,
+                crate::units::length::Link,
+                crate::units::length::Fathom,
+                crate::units::length::EarthMeridionalCircumference,
+                crate::units::length::EarthEquatorialCircumference,
+                crate::units::angular::Gradian
+            }
+            $($extra),+
+        );
+    };
+}
+
+#[cfg(feature = "land-area")]
+macro_rules! __impl_div_pairs_with_land_area_as_base {
+    ($($extra:ty),+ $(,)?) => {
+        crate::__impl_div_pairs_each_extra_to_bases!(
+            {
+                crate::units::area::Hectare,
+                crate::units::area::Are,
+                crate::units::area::Acre
+            }
+            $($extra),+
+        );
+    };
+}
+
+// ── Cross-feature UnitDiv pairs ──────────────────────────────────────────────
+//
+// When two optional feature families are both enabled, units from each family
+// need `UnitDiv` impls against each other so that cross-unit division "just
+// works".  Multiplication is already covered by the `BuiltinUnit` blanket impl;
+// division requires explicit pairs because the `U / U → Unitless` blanket
+// overlaps with a hypothetical `A / B → Per<A, B>` blanket.
+//
+// For each pair the macro of the *larger* family is invoked so that the smaller
+// family's (shorter) unit list is written at the call site.  Both `A / B` and
+// `B / A` impls are generated by one call — see `__impl_div_pairs_each_extra_to_bases!`.
+//
+// Pair count grows as C(N, 2) with N feature families; unit lists do not grow
+// with the pairing count because each list lives in exactly one macro above.
+
+// astro (24 units) — largest optional family; always the base for its pairs.
+#[cfg(all(feature = "astro", feature = "julian-time"))]
+__impl_div_pairs_with_astro_as_base!(
+    crate::units::time::JulianYear,
+    crate::units::time::JulianCentury
+);
+
+#[cfg(all(feature = "astro", feature = "customary"))]
+__impl_div_pairs_with_astro_as_base!(
+    crate::units::length::Inch,
+    crate::units::length::Foot,
+    crate::units::length::Yard,
+    crate::units::length::Mile,
+    crate::units::mass::Carat,
+    crate::units::mass::Grain,
+    crate::units::mass::Pound,
+    crate::units::mass::Ounce,
+    crate::units::mass::Stone,
+    crate::units::mass::ShortTon,
+    crate::units::mass::LongTon,
+    crate::units::power::HorsepowerMetric,
+    crate::units::power::HorsepowerElectric,
+    crate::units::area::SquareInch,
+    crate::units::area::SquareFoot,
+    crate::units::area::SquareYard,
+    crate::units::area::SquareMile,
+    crate::units::volume::CubicInch,
+    crate::units::volume::CubicFoot,
+    crate::units::volume::UsGallon,
+    crate::units::volume::UsFluidOunce,
+    crate::units::force::PoundForce,
+    crate::units::energy::Calorie,
+    crate::units::energy::Kilocalorie
+);
+
+#[cfg(all(feature = "astro", feature = "navigation"))]
+__impl_div_pairs_with_astro_as_base!(
+    crate::units::length::NauticalMile,
+    crate::units::length::Chain,
+    crate::units::length::Rod,
+    crate::units::length::Link,
+    crate::units::length::Fathom,
+    crate::units::length::EarthMeridionalCircumference,
+    crate::units::length::EarthEquatorialCircumference,
+    crate::units::angular::Gradian
+);
+
+#[cfg(all(feature = "astro", feature = "fundamental-physics"))]
+__impl_div_pairs_with_astro_as_base!(
+    crate::units::length::BohrRadius,
+    crate::units::length::ClassicalElectronRadius,
+    crate::units::length::PlanckLength,
+    crate::units::length::ElectronReducedComptonWavelength,
+    crate::units::mass::AtomicMassUnit,
+    crate::units::power::ErgPerSecond,
+    crate::units::force::Dyne,
+    crate::units::energy::Erg,
+    crate::units::energy::Electronvolt,
+    crate::units::energy::Kiloelectronvolt,
+    crate::units::energy::Megaelectronvolt
+);
+
+#[cfg(all(feature = "astro", feature = "land-area"))]
+__impl_div_pairs_with_astro_as_base!(
+    crate::units::area::Hectare,
+    crate::units::area::Are,
+    crate::units::area::Acre
+);
+
+// customary (23 units) — base for its pairs with smaller families.
+#[cfg(all(feature = "julian-time", feature = "customary"))]
+__impl_div_pairs_with_customary_as_base!(
+    crate::units::time::JulianYear,
+    crate::units::time::JulianCentury
+);
+
+#[cfg(all(feature = "customary", feature = "navigation"))]
+__impl_div_pairs_with_customary_as_base!(
+    crate::units::length::NauticalMile,
+    crate::units::length::Chain,
+    crate::units::length::Rod,
+    crate::units::length::Link,
+    crate::units::length::Fathom,
+    crate::units::length::EarthMeridionalCircumference,
+    crate::units::length::EarthEquatorialCircumference,
+    crate::units::angular::Gradian
+);
+
+#[cfg(all(feature = "customary", feature = "fundamental-physics"))]
+__impl_div_pairs_with_customary_as_base!(
+    crate::units::length::BohrRadius,
+    crate::units::length::ClassicalElectronRadius,
+    crate::units::length::PlanckLength,
+    crate::units::length::ElectronReducedComptonWavelength,
+    crate::units::mass::AtomicMassUnit,
+    crate::units::power::ErgPerSecond,
+    crate::units::force::Dyne,
+    crate::units::energy::Erg,
+    crate::units::energy::Electronvolt,
+    crate::units::energy::Kiloelectronvolt,
+    crate::units::energy::Megaelectronvolt
+);
+
+#[cfg(all(feature = "customary", feature = "land-area"))]
+__impl_div_pairs_with_customary_as_base!(
+    crate::units::area::Hectare,
+    crate::units::area::Are,
+    crate::units::area::Acre
+);
+
+// fundamental-physics (11 units) — base for its pairs with navigation and smaller families.
+#[cfg(all(feature = "julian-time", feature = "fundamental-physics"))]
+__impl_div_pairs_with_fundamental_physics_as_base!(
+    crate::units::time::JulianYear,
+    crate::units::time::JulianCentury
+);
+
+#[cfg(all(feature = "navigation", feature = "fundamental-physics"))]
+__impl_div_pairs_with_fundamental_physics_as_base!(
+    crate::units::length::NauticalMile,
+    crate::units::length::Chain,
+    crate::units::length::Rod,
+    crate::units::length::Link,
+    crate::units::length::Fathom,
+    crate::units::length::EarthMeridionalCircumference,
+    crate::units::length::EarthEquatorialCircumference,
+    crate::units::angular::Gradian
+);
+
+#[cfg(all(feature = "fundamental-physics", feature = "land-area"))]
+__impl_div_pairs_with_fundamental_physics_as_base!(
+    crate::units::area::Hectare,
+    crate::units::area::Are,
+    crate::units::area::Acre
+);
+
+// navigation (8 units) — base for its pairs with land-area and julian-time.
+#[cfg(all(feature = "julian-time", feature = "navigation"))]
+__impl_div_pairs_with_navigation_as_base!(
+    crate::units::time::JulianYear,
+    crate::units::time::JulianCentury
+);
+
+#[cfg(all(feature = "navigation", feature = "land-area"))]
+__impl_div_pairs_with_navigation_as_base!(
+    crate::units::area::Hectare,
+    crate::units::area::Are,
+    crate::units::area::Acre
+);
+
+// land-area (3 units) — base for the julian-time pair (land-area > julian-time).
+#[cfg(all(feature = "julian-time", feature = "land-area"))]
+__impl_div_pairs_with_land_area_as_base!(
+    crate::units::time::JulianYear,
+    crate::units::time::JulianCentury
+);

--- a/qtty-core/src/units/angular/mod.rs
+++ b/qtty-core/src/units/angular/mod.rs
@@ -342,6 +342,18 @@ angular_units!(crate::impl_unit_from_conversions);
 #[cfg(feature = "cross-unit-ops")]
 angular_units!(crate::impl_unit_cross_unit_ops);
 
+// ── Cross-feature: astro × navigation ────────────────────────────────────────
+#[cfg(all(feature = "astro", feature = "navigation"))]
+crate::__impl_from_each_extra_to_bases!(
+    {Arcminute, Arcsecond, MilliArcsecond, MicroArcsecond, HourAngle}
+    Gradian
+);
+#[cfg(all(feature = "astro", feature = "navigation", feature = "cross-unit-ops"))]
+crate::__impl_cross_ops_each_extra_to_bases!(
+    {Arcminute, Arcsecond, MilliArcsecond, MicroArcsecond, HourAngle}
+    Gradian
+);
+
 // Compile-time check: every base angular unit is registered as BuiltinUnit.
 #[cfg(test)]
 angular_units!(crate::assert_units_are_builtin);

--- a/qtty-core/src/units/angular_rate.rs
+++ b/qtty-core/src/units/angular_rate.rs
@@ -1,16 +1,19 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2026 Vallés Puig, Ramon
 
-//! Angular rate (angular frequency) unit aliases (`Angular / Time`).
+//! Angular rate (angular displacement per unit time) unit aliases (`Angular / Time`).
 //!
 //! This module models **angular rate** — angular displacement per unit time
 //! (e.g. radians/second, degrees/day). It does **not** model SI cycle frequency
 //! (Hz = cycles/s), which would be `T⁻¹` with dimensionless cycles.
 //!
+//! If you need Hertz-style inverse-time frequency, model it directly as
+//! `Per<Unitless, Second>` (or a named wrapper) — this module is the wrong place.
+//!
 //! ```rust
 //! use qtty_core::angular::{Degree, Radian};
 //! use qtty_core::time::Day;
-//! use qtty_core::frequency::AngularRate;
+//! use qtty_core::angular_rate::AngularRate;
 //!
 //! let f: AngularRate<Degree, Day> = AngularRate::new(180.0);
 //! let f_rad: AngularRate<Radian, Day> = f.to();
@@ -33,7 +36,7 @@ impl<T: Unit<Dim = crate::AngularRate>> AngularRateUnit for T {}
 /// ```rust
 /// use qtty_core::angular::{Degree, Radian};
 /// use qtty_core::time::{Second, Day};
-/// use qtty_core::frequency::AngularRate;
+/// use qtty_core::angular_rate::AngularRate;
 ///
 /// let f1: AngularRate<Degree, Second> = AngularRate::new(360.0);
 /// let f2: AngularRate<Radian, Day> = AngularRate::new(6.28);

--- a/qtty-core/src/units/area/mod.rs
+++ b/qtty-core/src/units/area/mod.rs
@@ -141,6 +141,22 @@ area_units!(crate::impl_unit_from_conversions);
 #[cfg(feature = "cross-unit-ops")]
 area_units!(crate::impl_unit_cross_unit_ops);
 
+// ── Cross-feature: customary × land-area ─────────────────────────────────────
+#[cfg(all(feature = "customary", feature = "land-area"))]
+crate::__impl_from_each_extra_to_bases!(
+    {SquareInch, SquareFoot, SquareYard, SquareMile}
+    Hectare, Are, Acre
+);
+#[cfg(all(
+    feature = "customary",
+    feature = "land-area",
+    feature = "cross-unit-ops"
+))]
+crate::__impl_cross_ops_each_extra_to_bases!(
+    {SquareInch, SquareFoot, SquareYard, SquareMile}
+    Hectare, Are, Acre
+);
+
 // Compile-time check: every unit in the inventory is registered as BuiltinUnit.
 #[cfg(test)]
 area_units!(crate::assert_units_are_builtin);

--- a/qtty-core/src/units/energy.rs
+++ b/qtty-core/src/units/energy.rs
@@ -141,6 +141,22 @@ energy_units!(crate::impl_unit_from_conversions);
 #[cfg(feature = "cross-unit-ops")]
 energy_units!(crate::impl_unit_cross_unit_ops);
 
+// ── Cross-feature: customary × fundamental-physics ───────────────────────────
+#[cfg(all(feature = "customary", feature = "fundamental-physics"))]
+crate::__impl_from_each_extra_to_bases!(
+    {Calorie, Kilocalorie}
+    Erg, Electronvolt, Kiloelectronvolt, Megaelectronvolt
+);
+#[cfg(all(
+    feature = "customary",
+    feature = "fundamental-physics",
+    feature = "cross-unit-ops"
+))]
+crate::__impl_cross_ops_each_extra_to_bases!(
+    {Calorie, Kilocalorie}
+    Erg, Electronvolt, Kiloelectronvolt, Megaelectronvolt
+);
+
 // Compile-time check: every base energy unit is registered as BuiltinUnit.
 #[cfg(test)]
 energy_units!(crate::assert_units_are_builtin);

--- a/qtty-core/src/units/force.rs
+++ b/qtty-core/src/units/force.rs
@@ -114,6 +114,22 @@ force_units!(crate::impl_unit_from_conversions);
 #[cfg(feature = "cross-unit-ops")]
 force_units!(crate::impl_unit_cross_unit_ops);
 
+// ── Cross-feature: customary × fundamental-physics ───────────────────────────
+#[cfg(all(feature = "customary", feature = "fundamental-physics"))]
+crate::__impl_from_each_extra_to_bases!(
+    {PoundForce}
+    Dyne
+);
+#[cfg(all(
+    feature = "customary",
+    feature = "fundamental-physics",
+    feature = "cross-unit-ops"
+))]
+crate::__impl_cross_ops_each_extra_to_bases!(
+    {PoundForce}
+    Dyne
+);
+
 // Compile-time check: every base force unit is registered as BuiltinUnit.
 #[cfg(test)]
 force_units!(crate::assert_units_are_builtin);

--- a/qtty-core/src/units/length/astro.rs
+++ b/qtty-core/src/units/length/astro.rs
@@ -159,12 +159,25 @@ pub mod nominal {
     /// One solar diameter.
     pub const D_SUN: SolarDiameters = SolarDiameters::new(1.0);
 
-    // Allow convenient conversions between selected nominal units and core
-    // length units (e.g., SolarRadius <-> Kilometer) without polluting the
-    // main length namespace with nominal types.
-    crate::impl_unit_from_conversions!(SolarRadius, Kilometer);
+    // ── nominal ↔ base metric conversions ────────────────────────────────────
+    // Wire all nominal units against the full base metric set so they get the
+    // same `From` and cross-unit comparison surface as "real" astro units.
+    crate::impl_unit_from_conversions_between!(
+        Meter, Decimeter, Centimeter, Millimeter, Micrometer, Nanometer, Picometer, Femtometer,
+        Attometer, Zeptometer, Yoctometer, Decameter, Hectometer, Kilometer, Megameter, Gigameter,
+        Terameter, Petameter, Exameter, Zettameter, Yottameter;
+        SolarRadius, SolarDiameter, EarthRadius, EarthEquatorialRadius, EarthPolarRadius,
+        LunarRadius, JupiterRadius, LunarDistance
+    );
+
     #[cfg(feature = "cross-unit-ops")]
-    crate::impl_unit_cross_unit_ops!(SolarRadius, Kilometer);
+    crate::impl_unit_cross_unit_ops_between!(
+        Meter, Decimeter, Centimeter, Millimeter, Micrometer, Nanometer, Picometer, Femtometer,
+        Attometer, Zeptometer, Yoctometer, Decameter, Hectometer, Kilometer, Megameter, Gigameter,
+        Terameter, Petameter, Exameter, Zettameter, Yottameter;
+        SolarRadius, SolarDiameter, EarthRadius, EarthEquatorialRadius, EarthPolarRadius,
+        LunarRadius, JupiterRadius, LunarDistance
+    );
 }
 
 // ── astro ────────────────────────────────────────────────────────────────
@@ -181,6 +194,22 @@ crate::impl_unit_cross_unit_ops_between!(
     Attometer, Zeptometer, Yoctometer, Decameter, Hectometer, Kilometer, Megameter, Gigameter,
     Terameter, Petameter, Exameter, Zettameter, Yottameter;
     AstronomicalUnit, LightYear, Parsec, Kiloparsec, Megaparsec, Gigaparsec
+);
+
+// ── nominal ↔ astro conversions ──────────────────────────────────────────
+crate::__impl_from_each_extra_to_bases!(
+    {AstronomicalUnit, LightYear, Parsec, Kiloparsec, Megaparsec, Gigaparsec}
+    nominal::SolarRadius, nominal::SolarDiameter, nominal::EarthRadius,
+    nominal::EarthEquatorialRadius, nominal::EarthPolarRadius,
+    nominal::JupiterRadius, nominal::LunarRadius, nominal::LunarDistance
+);
+
+#[cfg(feature = "cross-unit-ops")]
+crate::__impl_cross_ops_each_extra_to_bases!(
+    {AstronomicalUnit, LightYear, Parsec, Kiloparsec, Megaparsec, Gigaparsec}
+    nominal::SolarRadius, nominal::SolarDiameter, nominal::EarthRadius,
+    nominal::EarthEquatorialRadius, nominal::EarthPolarRadius,
+    nominal::JupiterRadius, nominal::LunarRadius, nominal::LunarDistance
 );
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/qtty-core/src/units/length/fundamental_physics.rs
+++ b/qtty-core/src/units/length/fundamental_physics.rs
@@ -5,28 +5,28 @@ use super::*;
 use qtty_derive::Unit;
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Fundamental physics lengths (CODATA values)
+// Fundamental physics lengths (CODATA 2022 recommended values)
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Bohr radius (`a0`). CODATA 2018 value in metres.
+/// Bohr radius (`a0`). CODATA 2022 value in metres.
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Unit)]
-#[unit(symbol = "a0", dimension = Length, ratio = 5.291_772_109_03e-11)]
+#[unit(symbol = "a0", dimension = Length, ratio = 5.291_772_105_44e-11)]
 pub struct BohrRadius;
 /// A quantity measured in Bohr radii.
 pub type BohrRadii = Quantity<BohrRadius>;
 /// One Bohr radius.
 pub const A0: BohrRadii = BohrRadii::new(1.0);
 
-/// Classical electron radius (`re`). CODATA 2018 value in metres.
+/// Classical electron radius (`re`). CODATA 2022 value in metres.
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Unit)]
-#[unit(symbol = "re", dimension = Length, ratio = 2.817_940_326_2e-15)]
+#[unit(symbol = "re", dimension = Length, ratio = 2.817_940_320_5e-15)]
 pub struct ClassicalElectronRadius;
 /// A quantity measured in classical electron radii.
 pub type ClassicalElectronRadii = Quantity<ClassicalElectronRadius>;
 /// One classical electron radius.
 pub const RE: ClassicalElectronRadii = ClassicalElectronRadii::new(1.0);
 
-/// Planck length (`lp`). CODATA 2018 value in metres.
+/// Planck length (`lp`). CODATA 2022 value in metres.
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Unit)]
 #[unit(symbol = "lp", dimension = Length, ratio = 1.616_255e-35)]
 pub struct PlanckLength;
@@ -35,9 +35,9 @@ pub type PlanckLengths = Quantity<PlanckLength>;
 /// One Planck length.
 pub const LP: PlanckLengths = PlanckLengths::new(1.0);
 
-/// Reduced Compton wavelength of the electron (`lambda_bar_e`). CODATA 2018 value in metres.
+/// Reduced Compton wavelength of the electron (`lambda_bar_e`). CODATA 2022 value in metres.
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Unit)]
-#[unit(symbol = "lambda_bar_e", dimension = Length, ratio = 3.861_592_679_6e-13)]
+#[unit(symbol = "lambda_bar_e", dimension = Length, ratio = 3.861_592_674_4e-13)]
 pub struct ElectronReducedComptonWavelength;
 /// A quantity measured in reduced Compton wavelengths of the electron.
 pub type ElectronReducedComptonWavelengths = Quantity<ElectronReducedComptonWavelength>;

--- a/qtty-core/src/units/length/mod.rs
+++ b/qtty-core/src/units/length/mod.rs
@@ -331,6 +331,119 @@ length_units!(crate::impl_unit_from_conversions);
 #[cfg(feature = "cross-unit-ops")]
 length_units!(crate::impl_unit_cross_unit_ops);
 
+// ── Per-family bridge helpers ─────────────────────────────────────────────────
+//
+// Each macro below holds ONE optional feature's length unit list and invokes
+// both the `From` and (when `cross-unit-ops` is enabled) the `PartialEq`/
+// `PartialOrd` generators.  The astro-length set is the largest family in this
+// module; defining it once here cuts its appearance count from once-per-pair
+// to one macro body.
+//
+// To add a new optional length family F:
+//   1. Define `__impl_length_bridges_with_F_as_base!` here with F's unit list.
+//   2. Add one call per existing family X (invoking whichever family's macro
+//      covers the larger set of length units).
+
+#[cfg(feature = "astro")]
+macro_rules! __impl_length_bridges_with_astro_as_base {
+    ($($extra:ty),+ $(,)?) => {
+        crate::__impl_from_each_extra_to_bases!(
+            {
+                AstronomicalUnit, LightYear, Parsec, Kiloparsec, Megaparsec, Gigaparsec,
+                nominal::SolarRadius, nominal::SolarDiameter, nominal::EarthRadius,
+                nominal::EarthEquatorialRadius, nominal::EarthPolarRadius,
+                nominal::JupiterRadius, nominal::LunarRadius, nominal::LunarDistance
+            }
+            $($extra),+
+        );
+        #[cfg(feature = "cross-unit-ops")]
+        crate::__impl_cross_ops_each_extra_to_bases!(
+            {
+                AstronomicalUnit, LightYear, Parsec, Kiloparsec, Megaparsec, Gigaparsec,
+                nominal::SolarRadius, nominal::SolarDiameter, nominal::EarthRadius,
+                nominal::EarthEquatorialRadius, nominal::EarthPolarRadius,
+                nominal::JupiterRadius, nominal::LunarRadius, nominal::LunarDistance
+            }
+            $($extra),+
+        );
+    };
+}
+
+#[cfg(feature = "navigation")]
+macro_rules! __impl_length_bridges_with_navigation_as_base {
+    ($($extra:ty),+ $(,)?) => {
+        crate::__impl_from_each_extra_to_bases!(
+            {NauticalMile, Chain, Rod, Link, Fathom, EarthMeridionalCircumference, EarthEquatorialCircumference}
+            $($extra),+
+        );
+        #[cfg(feature = "cross-unit-ops")]
+        crate::__impl_cross_ops_each_extra_to_bases!(
+            {NauticalMile, Chain, Rod, Link, Fathom, EarthMeridionalCircumference, EarthEquatorialCircumference}
+            $($extra),+
+        );
+    };
+}
+
+// ── Cross-feature From/PartialEq/PartialOrd: length families ─────────────────
+//
+// Each feature-gated submodule registers its extra units against the base metric
+// set.  The calls below close the gap so that units from *different* optional
+// features also get bidirectional `From` and cross-unit comparison impls.
+//
+// The macro of the *larger* length family is always invoked so the smaller
+// family's (shorter) unit list appears at the call site.
+
+// astro (14 length units) — largest optional length family; always the base.
+#[cfg(all(feature = "astro", feature = "customary"))]
+__impl_length_bridges_with_astro_as_base!(Inch, Foot, Yard, Mile);
+
+#[cfg(all(feature = "astro", feature = "navigation"))]
+__impl_length_bridges_with_astro_as_base!(
+    NauticalMile,
+    Chain,
+    Rod,
+    Link,
+    Fathom,
+    EarthMeridionalCircumference,
+    EarthEquatorialCircumference
+);
+
+#[cfg(all(feature = "astro", feature = "fundamental-physics"))]
+__impl_length_bridges_with_astro_as_base!(
+    BohrRadius,
+    ClassicalElectronRadius,
+    PlanckLength,
+    ElectronReducedComptonWavelength
+);
+
+// navigation (7 length units) — base for its pairs with customary (4) and fp (4).
+#[cfg(all(feature = "customary", feature = "navigation"))]
+__impl_length_bridges_with_navigation_as_base!(Inch, Foot, Yard, Mile);
+
+#[cfg(all(feature = "navigation", feature = "fundamental-physics"))]
+__impl_length_bridges_with_navigation_as_base!(
+    BohrRadius,
+    ClassicalElectronRadius,
+    PlanckLength,
+    ElectronReducedComptonWavelength
+);
+
+// customary (4) and fundamental-physics (4) are equal in size; customary is base by convention.
+#[cfg(all(feature = "customary", feature = "fundamental-physics"))]
+crate::__impl_from_each_extra_to_bases!(
+    {Inch, Foot, Yard, Mile}
+    BohrRadius, ClassicalElectronRadius, PlanckLength, ElectronReducedComptonWavelength
+);
+#[cfg(all(
+    feature = "customary",
+    feature = "fundamental-physics",
+    feature = "cross-unit-ops"
+))]
+crate::__impl_cross_ops_each_extra_to_bases!(
+    {Inch, Foot, Yard, Mile}
+    BohrRadius, ClassicalElectronRadius, PlanckLength, ElectronReducedComptonWavelength
+);
+
 // Compile-time check: every base length unit is registered as BuiltinUnit.
 #[cfg(test)]
 length_units!(crate::assert_units_are_builtin);
@@ -850,10 +963,10 @@ mod tests {
     #[cfg(feature = "fundamental-physics")]
     fn classical_electron_radius_to_femtometers() {
         let q = ClassicalElectronRadii::new(1.0);
-        // re ≈ 2.81794 fm
+        // re ≈ 2.81794 fm (CODATA 2022)
         assert_relative_eq!(
             q.to::<Femtometer>().value(),
-            2.817_940_326_2,
+            2.817_940_320_5,
             max_relative = 1e-9
         );
     }
@@ -871,10 +984,10 @@ mod tests {
     #[cfg(feature = "fundamental-physics")]
     fn electron_compton_wavelength_to_femtometers() {
         let q = ElectronReducedComptonWavelengths::new(1.0);
-        // λ̄_e ≈ 386.159 fm
+        // λ̄_e ≈ 386.159 fm (CODATA 2022)
         assert_relative_eq!(
             q.to::<Femtometer>().value(),
-            386.159_267_96,
+            386.159_267_44,
             max_relative = 1e-7
         );
     }

--- a/qtty-core/src/units/mass/fundamental_physics.rs
+++ b/qtty-core/src/units/mass/fundamental_physics.rs
@@ -6,7 +6,7 @@ use qtty_derive::Unit;
 
 /// Unified atomic mass unit (u), a.k.a. dalton (Da).
 ///
-/// Stored in grams using the CODATA recommended value for `m_u` in kilograms, converted by `1 kg = 1000 g`.
+/// Stored in grams using the CODATA 2022 recommended value for `m_u` in kilograms, converted by `1 kg = 1000 g`.
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Unit)]
 #[unit(symbol = "u", dimension = Mass, ratio = 1.660_539_068_92e-24)]
 pub struct AtomicMassUnit;

--- a/qtty-core/src/units/mass/mod.rs
+++ b/qtty-core/src/units/mass/mod.rs
@@ -151,6 +151,48 @@ mass_units!(crate::impl_unit_from_conversions);
 #[cfg(feature = "cross-unit-ops")]
 mass_units!(crate::impl_unit_cross_unit_ops);
 
+// ── Cross-feature: mass families ─────────────────────────────────────────────
+#[cfg(all(feature = "astro", feature = "customary"))]
+crate::__impl_from_each_extra_to_bases!(
+    {SolarMass}
+    Carat, Grain, Pound, Ounce, Stone, ShortTon, LongTon
+);
+#[cfg(all(feature = "astro", feature = "customary", feature = "cross-unit-ops"))]
+crate::__impl_cross_ops_each_extra_to_bases!(
+    {SolarMass}
+    Carat, Grain, Pound, Ounce, Stone, ShortTon, LongTon
+);
+
+#[cfg(all(feature = "astro", feature = "fundamental-physics"))]
+crate::__impl_from_each_extra_to_bases!(
+    {SolarMass}
+    AtomicMassUnit
+);
+#[cfg(all(
+    feature = "astro",
+    feature = "fundamental-physics",
+    feature = "cross-unit-ops"
+))]
+crate::__impl_cross_ops_each_extra_to_bases!(
+    {SolarMass}
+    AtomicMassUnit
+);
+
+#[cfg(all(feature = "customary", feature = "fundamental-physics"))]
+crate::__impl_from_each_extra_to_bases!(
+    {Carat, Grain, Pound, Ounce, Stone, ShortTon, LongTon}
+    AtomicMassUnit
+);
+#[cfg(all(
+    feature = "customary",
+    feature = "fundamental-physics",
+    feature = "cross-unit-ops"
+))]
+crate::__impl_cross_ops_each_extra_to_bases!(
+    {Carat, Grain, Pound, Ounce, Stone, ShortTon, LongTon}
+    AtomicMassUnit
+);
+
 // Compile-time check: every base mass unit is registered as BuiltinUnit.
 #[cfg(test)]
 mass_units!(crate::assert_units_are_builtin);

--- a/qtty-core/src/units/mod.rs
+++ b/qtty-core/src/units/mod.rs
@@ -19,15 +19,16 @@
 //! - [`force`]: force units (SI newton is canonical scaling unit).
 //! - [`energy`]: energy units (SI joule is canonical scaling unit).
 //! - [`power`]: power units (watt is canonical scaling unit).
-//! - [`frequency`]: angular frequency aliases (`Angular / Time`) built from [`angular`] and [`time`].
+//! - [`angular_rate`]: angular-rate aliases (`Angular / Time`) built from [`angular`] and [`time`].
+//!   This is **not** SI Hertz-style inverse-time frequency (`T⁻¹`); see the module docs.
 //! - [`unitless`]: helpers for dimensionless quantities.
 
 pub mod acceleration;
 pub mod angular;
+pub mod angular_rate;
 pub mod area;
 pub mod energy;
 pub mod force;
-pub mod frequency;
 pub mod length;
 pub mod mass;
 pub mod power;

--- a/qtty-core/src/units/power/mod.rs
+++ b/qtty-core/src/units/power/mod.rs
@@ -129,6 +129,48 @@ power_units!(crate::impl_unit_from_conversions);
 #[cfg(feature = "cross-unit-ops")]
 power_units!(crate::impl_unit_cross_unit_ops);
 
+// ── Cross-feature: power families ────────────────────────────────────────────
+#[cfg(all(feature = "astro", feature = "customary"))]
+crate::__impl_from_each_extra_to_bases!(
+    {SolarLuminosity}
+    HorsepowerMetric, HorsepowerElectric
+);
+#[cfg(all(feature = "astro", feature = "customary", feature = "cross-unit-ops"))]
+crate::__impl_cross_ops_each_extra_to_bases!(
+    {SolarLuminosity}
+    HorsepowerMetric, HorsepowerElectric
+);
+
+#[cfg(all(feature = "astro", feature = "fundamental-physics"))]
+crate::__impl_from_each_extra_to_bases!(
+    {SolarLuminosity}
+    ErgPerSecond
+);
+#[cfg(all(
+    feature = "astro",
+    feature = "fundamental-physics",
+    feature = "cross-unit-ops"
+))]
+crate::__impl_cross_ops_each_extra_to_bases!(
+    {SolarLuminosity}
+    ErgPerSecond
+);
+
+#[cfg(all(feature = "customary", feature = "fundamental-physics"))]
+crate::__impl_from_each_extra_to_bases!(
+    {HorsepowerMetric, HorsepowerElectric}
+    ErgPerSecond
+);
+#[cfg(all(
+    feature = "customary",
+    feature = "fundamental-physics",
+    feature = "cross-unit-ops"
+))]
+crate::__impl_cross_ops_each_extra_to_bases!(
+    {HorsepowerMetric, HorsepowerElectric}
+    ErgPerSecond
+);
+
 // Compile-time check: every base power unit is registered as BuiltinUnit.
 #[cfg(test)]
 power_units!(crate::assert_units_are_builtin);

--- a/qtty-core/src/units/time/astro.rs
+++ b/qtty-core/src/units/time/astro.rs
@@ -39,6 +39,24 @@ pub type SiderealYears = Quantity<SiderealYear>;
 /// A constant representing one sidereal year.
 pub const SIDEREAL_YEAR: SiderealYears = SiderealYears::new(1.0);
 
+// ── Conversions: astro time ↔ base time ──────────────────────────────────────
+crate::impl_unit_from_conversions_between!(
+    Attosecond, Femtosecond, Picosecond, Nanosecond, Microsecond, Millisecond,
+    Centisecond, Decisecond, Second, Decasecond, Hectosecond, Kilosecond,
+    Megasecond, Gigasecond, Terasecond, Minute, Hour, Day, Week, Fortnight,
+    Year, Decade, Century, Millennium;
+    SiderealDay, SynodicMonth, SiderealYear
+);
+
+#[cfg(feature = "cross-unit-ops")]
+crate::impl_unit_cross_unit_ops_between!(
+    Attosecond, Femtosecond, Picosecond, Nanosecond, Microsecond, Millisecond,
+    Centisecond, Decisecond, Second, Decasecond, Hectosecond, Kilosecond,
+    Megasecond, Gigasecond, Terasecond, Minute, Hour, Day, Week, Fortnight,
+    Year, Decade, Century, Millennium;
+    SiderealDay, SynodicMonth, SiderealYear
+);
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Inventory macro (used by qtty-ffi build.rs)
 // ─────────────────────────────────────────────────────────────────────────────

--- a/qtty-core/src/units/time/julian_time.rs
+++ b/qtty-core/src/units/time/julian_time.rs
@@ -24,6 +24,24 @@ pub type JulianCenturies = Quantity<JulianCentury>;
 /// A constant representing one Julian century.
 pub const JULIAN_CENTURY: JulianCenturies = JulianCenturies::new(1.0);
 
+// ── Conversions: julian time ↔ base time ─────────────────────────────────────
+crate::impl_unit_from_conversions_between!(
+    Attosecond, Femtosecond, Picosecond, Nanosecond, Microsecond, Millisecond,
+    Centisecond, Decisecond, Second, Decasecond, Hectosecond, Kilosecond,
+    Megasecond, Gigasecond, Terasecond, Minute, Hour, Day, Week, Fortnight,
+    Year, Decade, Century, Millennium;
+    JulianYear, JulianCentury
+);
+
+#[cfg(feature = "cross-unit-ops")]
+crate::impl_unit_cross_unit_ops_between!(
+    Attosecond, Femtosecond, Picosecond, Nanosecond, Microsecond, Millisecond,
+    Centisecond, Decisecond, Second, Decasecond, Hectosecond, Kilosecond,
+    Megasecond, Gigasecond, Terasecond, Minute, Hour, Day, Week, Fortnight,
+    Year, Decade, Century, Millennium;
+    JulianYear, JulianCentury
+);
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Inventory macro (used by qtty-ffi build.rs)
 // ─────────────────────────────────────────────────────────────────────────────

--- a/qtty-core/src/units/time/mod.rs
+++ b/qtty-core/src/units/time/mod.rs
@@ -65,6 +65,10 @@ impl<T: Unit<Dim = Time>> TimeUnit for T {}
 /// Conventional civil mapping used by this module: seconds per mean solar day.
 pub const SECONDS_PER_DAY: f64 = 86_400.0;
 
+/// Mean Gregorian year length in days (accounts for the leap-year rule:
+/// every 4 years except centuries not divisible by 400).
+pub const DAYS_PER_GREGORIAN_YEAR: f64 = 365.242_5;
+
 #[cfg(feature = "julian-time")]
 mod julian_time;
 #[cfg(feature = "julian-time")]
@@ -264,7 +268,7 @@ pub const FORTNIGHT: Fortnights = Fortnights::new(1.0);
 ///
 /// Convention used: `365.2425 d`.
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Unit)]
-#[unit(symbol = "yr", dimension = Time, ratio = 365.242_5 * SECONDS_PER_DAY)]
+#[unit(symbol = "yr", dimension = Time, ratio = DAYS_PER_GREGORIAN_YEAR * SECONDS_PER_DAY)]
 pub struct Year;
 /// A quantity measured in years.
 pub type Years = Quantity<Year>;
@@ -273,7 +277,7 @@ pub const YEAR: Years = Years::new(1.0);
 
 /// Decade (`10` mean tropical years).
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Unit)]
-#[unit(symbol = "dec", dimension = Time, ratio = 10.0 * 365.242_5 * SECONDS_PER_DAY)]
+#[unit(symbol = "dec", dimension = Time, ratio = 10.0 * DAYS_PER_GREGORIAN_YEAR * SECONDS_PER_DAY)]
 pub struct Decade;
 /// A quantity measured in decades.
 pub type Decades = Quantity<Decade>;
@@ -282,7 +286,7 @@ pub const DECADE: Decades = Decades::new(1.0);
 
 /// Century (`100` mean tropical years).
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Unit)]
-#[unit(symbol = "c", dimension = Time, ratio = 100.0 * 365.242_5 * SECONDS_PER_DAY)]
+#[unit(symbol = "c", dimension = Time, ratio = 100.0 * DAYS_PER_GREGORIAN_YEAR * SECONDS_PER_DAY)]
 pub struct Century;
 /// A quantity measured in centuries.
 pub type Centuries = Quantity<Century>;
@@ -291,7 +295,7 @@ pub const CENTURY: Centuries = Centuries::new(1.0);
 
 /// Millennium (`1000` mean tropical years).
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Unit)]
-#[unit(symbol = "mill", dimension = Time, ratio = 1000.0 * 365.242_5 * SECONDS_PER_DAY)]
+#[unit(symbol = "mill", dimension = Time, ratio = 1000.0 * DAYS_PER_GREGORIAN_YEAR * SECONDS_PER_DAY)]
 pub struct Millennium;
 /// A quantity measured in millennia.
 pub type Millennia = Quantity<Millennium>;
@@ -342,6 +346,19 @@ time_units!(crate::impl_unit_from_conversions);
 // Optional cross-unit operator support.
 #[cfg(feature = "cross-unit-ops")]
 time_units!(crate::impl_unit_cross_unit_ops);
+
+// ── Cross-feature: astro × julian-time ────────────────────────────────────────
+#[cfg(all(feature = "astro", feature = "julian-time"))]
+crate::__impl_from_each_extra_to_bases!(
+    {SiderealDay, SynodicMonth, SiderealYear}
+    JulianYear, JulianCentury
+);
+
+#[cfg(all(feature = "astro", feature = "julian-time", feature = "cross-unit-ops"))]
+crate::__impl_cross_ops_each_extra_to_bases!(
+    {SiderealDay, SynodicMonth, SiderealYear}
+    JulianYear, JulianCentury
+);
 
 // Compile-time check: every base time unit is registered as BuiltinUnit.
 #[cfg(test)]

--- a/qtty-core/tests/unit_arithmetic.rs
+++ b/qtty-core/tests/unit_arithmetic.rs
@@ -166,6 +166,18 @@ impl Unit for CustomLengthB {
 // Register custom units for arithmetic.
 qtty_core::impl_unit_arithmetic_pairs!(CustomLengthA, CustomLengthB);
 
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
+pub enum CustomLengthC {}
+impl Unit for CustomLengthC {
+    const RATIO: f64 = 1.7018;
+    type Dim = Length;
+    const SYMBOL: &'static str = "clc";
+}
+
+// Register a custom unit against selected built-ins without regenerating
+// built-in/built-in impls.
+qtty_core::impl_unit_arithmetic_pairs_between!(Meter, Kilometer; CustomLengthC);
+
 #[test]
 fn custom_unit_same_division_gives_unitless() {
     let a = Quantity::<CustomLengthA>::new(10.0);
@@ -195,6 +207,30 @@ fn custom_unit_self_multiplication() {
     let a = Quantity::<CustomLengthA>::new(3.0);
     let b = Quantity::<CustomLengthA>::new(4.0);
     let product: Quantity<Prod<CustomLengthA, CustomLengthA>> = a * b;
+    assert!((product.value() - 12.0).abs() < 1e-12);
+}
+
+#[test]
+fn custom_unit_between_group_division() {
+    let distance = Quantity::<Meter>::new(10.0);
+    let custom = Quantity::<CustomLengthC>::new(2.0);
+    let ratio: Quantity<Per<Meter, CustomLengthC>> = distance / custom;
+    assert!((ratio.value() - 5.0).abs() < 1e-12);
+}
+
+#[test]
+fn custom_unit_between_group_multiplication() {
+    let custom = Quantity::<CustomLengthC>::new(3.0);
+    let distance = Quantity::<Kilometer>::new(4.0);
+    let product: Quantity<Prod<CustomLengthC, Kilometer>> = custom * distance;
+    assert!((product.value() - 12.0).abs() < 1e-12);
+}
+
+#[test]
+fn custom_unit_between_group_self_multiplication() {
+    let a = Quantity::<CustomLengthC>::new(3.0);
+    let b = Quantity::<CustomLengthC>::new(4.0);
+    let product: Quantity<Prod<CustomLengthC, CustomLengthC>> = a * b;
     assert!((product.value() - 12.0).abs() < 1e-12);
 }
 

--- a/qtty-derive/src/lib.rs
+++ b/qtty-derive/src/lib.rs
@@ -3,9 +3,10 @@
 
 //! Derive macro implementation used by `qtty-core`.
 //!
-//! `qtty-derive` is an implementation detail of this workspace. The `Unit` derive expands in terms of `crate::Unit`
-//! and `crate::Quantity`, so it is intended to be used by `qtty-core` (or by crates that expose an identical
-//! crate-root API).
+//! `qtty-derive` is an implementation detail of this workspace. By default the
+//! `Unit` derive expands in terms of `crate::Unit` and `crate::Quantity`, which
+//! matches `qtty-core`. Downstream crates can target the public `qtty` facade by
+//! adding `crate = qtty` to the helper attribute.
 //!
 //! Most users should depend on `qtty` instead and use the predefined units.
 //!
@@ -14,7 +15,8 @@
 //! For a unit marker type `MyUnit`, the derive implements:
 //!
 //! - `crate::Unit for MyUnit`
-//! - `core::fmt::Display for crate::Quantity<MyUnit>` (formats as `<value> <symbol>`)
+//! - when targeting the defining crate itself, formatting impls for
+//!   `crate::Quantity<MyUnit, S>` (`Display`, `LowerExp`, `UpperExp`)
 //!
 //! # Attributes
 //!
@@ -23,6 +25,7 @@
 //! - `symbol = "m"`: displayed unit symbol
 //! - `dimension = SomeDim`: dimension marker type
 //! - `ratio = 1000.0`: conversion ratio to the canonical unit of the dimension
+//! - `crate = qtty`: optional crate path when deriving from a downstream crate
 
 #![deny(missing_docs)]
 #![forbid(unsafe_code)]
@@ -31,13 +34,19 @@ use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 use syn::{
+    ext::IdentExt,
     parse::{Parse, ParseStream},
-    parse_macro_input, Attribute, DeriveInput, Expr, Ident, LitStr, Token,
+    parse_macro_input, Attribute, DeriveInput, Expr, Ident, LitStr, Path, Token,
 };
 
 /// Derive `crate::Unit` and a `Display` impl for `crate::Quantity<ThisUnit>`.
 ///
-/// The derive must be paired with a `#[unit(...)]` attribute providing `symbol`, `dimension`, and `ratio`.
+/// The derive must be paired with a `#[unit(...)]` attribute providing
+/// `symbol`, `dimension`, and `ratio`. Downstream crates using the public
+/// `qtty` facade should also set `crate = qtty`.
+///
+/// Note that downstream crates only receive the `Unit` impl. Formatting impls
+/// for `qtty::Quantity<CustomUnit, S>` would violate Rust's orphan rules.
 ///
 /// This macro is intended for use by `qtty-core`.
 #[proc_macro_derive(Unit, attributes(unit))]
@@ -59,39 +68,58 @@ fn derive_unit_impl(input: DeriveInput) -> syn::Result<TokenStream2> {
     let symbol = &unit_attr.symbol;
     let dimension = &unit_attr.dimension;
     let ratio = &unit_attr.ratio;
+    let emit_quantity_formatting = unit_attr
+        .crate_path
+        .as_ref()
+        .is_none_or(|path| path.is_ident("crate"));
+    let crate_path = unit_attr
+        .crate_path
+        .as_ref()
+        .map(|path| quote!(#path))
+        .unwrap_or_else(|| quote!(crate));
 
     let expanded = quote! {
-        impl crate::Unit for #name {
+        impl #crate_path::Unit for #name {
             const RATIO: f64 = #ratio;
             type Dim = #dimension;
             const SYMBOL: &'static str = #symbol;
         }
 
-        impl<S: crate::scalar::Scalar + ::core::fmt::Display> ::core::fmt::Display for crate::Quantity<#name, S> {
-            fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-                // Forward all format flags (precision, width, fill, …) to the
-                // inner scalar so that e.g. `format!("{:.9}", my_au)` works.
-                ::core::fmt::Display::fmt(&self.value(), f)?;
-                write!(f, " {}", <#name as crate::Unit>::SYMBOL)
-            }
-        }
-
-        impl<S: crate::scalar::Scalar + ::core::fmt::LowerExp> ::core::fmt::LowerExp for crate::Quantity<#name, S> {
-            fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-                ::core::fmt::LowerExp::fmt(&self.value(), f)?;
-                write!(f, " {}", <#name as crate::Unit>::SYMBOL)
-            }
-        }
-
-        impl<S: crate::scalar::Scalar + ::core::fmt::UpperExp> ::core::fmt::UpperExp for crate::Quantity<#name, S> {
-            fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-                ::core::fmt::UpperExp::fmt(&self.value(), f)?;
-                write!(f, " {}", <#name as crate::Unit>::SYMBOL)
-            }
-        }
     };
 
-    Ok(expanded)
+    let formatting = if emit_quantity_formatting {
+        quote! {
+            impl<S: #crate_path::Scalar + ::core::fmt::Display> ::core::fmt::Display for #crate_path::Quantity<#name, S> {
+                fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+                    // Forward all format flags (precision, width, fill, …) to the
+                    // inner scalar so that e.g. `format!("{:.9}", my_au)` works.
+                    ::core::fmt::Display::fmt(&self.value(), f)?;
+                    write!(f, " {}", <#name as #crate_path::Unit>::SYMBOL)
+                }
+            }
+
+            impl<S: #crate_path::Scalar + ::core::fmt::LowerExp> ::core::fmt::LowerExp for #crate_path::Quantity<#name, S> {
+                fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+                    ::core::fmt::LowerExp::fmt(&self.value(), f)?;
+                    write!(f, " {}", <#name as #crate_path::Unit>::SYMBOL)
+                }
+            }
+
+            impl<S: #crate_path::Scalar + ::core::fmt::UpperExp> ::core::fmt::UpperExp for #crate_path::Quantity<#name, S> {
+                fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+                    ::core::fmt::UpperExp::fmt(&self.value(), f)?;
+                    write!(f, " {}", <#name as #crate_path::Unit>::SYMBOL)
+                }
+            }
+        }
+    } else {
+        TokenStream2::new()
+    };
+
+    Ok(quote! {
+        #expanded
+        #formatting
+    })
 }
 
 /// Parsed contents of the `#[unit(...)]` attribute.
@@ -99,6 +127,7 @@ struct UnitAttribute {
     symbol: LitStr,
     dimension: Expr,
     ratio: Expr,
+    crate_path: Option<Path>,
     // Future extensions:
     // long_name: Option<LitStr>,
     // plural: Option<LitStr>,
@@ -112,12 +141,16 @@ impl Parse for UnitAttribute {
         let mut symbol: Option<LitStr> = None;
         let mut dimension: Option<Expr> = None;
         let mut ratio: Option<Expr> = None;
+        let mut crate_path: Option<Path> = None;
 
         while !input.is_empty() {
-            let ident: Ident = input.parse()?;
+            let ident = Ident::parse_any(input)?;
             input.parse::<Token![=]>()?;
 
             match ident.to_string().as_str() {
+                "crate" => {
+                    crate_path = Some(input.parse()?);
+                }
                 "symbol" => {
                     symbol = Some(input.parse()?);
                 }
@@ -159,6 +192,7 @@ impl Parse for UnitAttribute {
             symbol,
             dimension,
             ratio,
+            crate_path,
         })
     }
 }
@@ -191,6 +225,20 @@ mod tests {
 
         let attr = parse_unit_attribute(&input.attrs).unwrap();
         assert_eq!(attr.symbol.value(), "m");
+        assert!(attr.crate_path.is_none());
+    }
+
+    #[test]
+    fn test_parse_unit_attribute_with_crate_path() {
+        let input: DeriveInput = parse_quote! {
+            #[unit(crate = qtty, symbol = "m", dimension = qtty::Length, ratio = 1.0)]
+            pub enum Meter {}
+        };
+
+        let attr = parse_unit_attribute(&input.attrs).unwrap();
+        assert_eq!(attr.symbol.value(), "m");
+        let crate_path = attr.crate_path.as_ref().unwrap();
+        assert_eq!(quote!(#crate_path).to_string(), "qtty");
     }
 
     #[test]
@@ -291,6 +339,21 @@ mod tests {
         let tokens = result.unwrap();
         let code = tokens.to_string();
         assert!(code.contains("const RATIO : f64 = 1000.0"));
+    }
+
+    #[test]
+    fn test_derive_unit_impl_with_downstream_crate_path() {
+        let input: DeriveInput = parse_quote! {
+            #[unit(crate = qtty, symbol = "smoot", dimension = qtty::Length, ratio = 1.7018)]
+            pub enum Smoot {}
+        };
+
+        let result = derive_unit_impl(input);
+        assert!(result.is_ok());
+        let tokens = result.unwrap();
+        let code = tokens.to_string();
+        assert!(code.contains("impl qtty :: Unit for Smoot"));
+        assert!(!code.contains("for qtty :: Quantity < Smoot , S >"));
     }
 
     #[test]

--- a/qtty/README.md
+++ b/qtty/README.md
@@ -12,7 +12,7 @@ code without giving up ergonomics.
 
 - Zero-cost `Quantity<U, S>` model with compile-time unit safety
 - Explicit conversions via `.to::<TargetUnit>()`
-- Dimensional arithmetic for area, volume, velocity, frequency, and other derived quantities
+- Dimensional arithmetic for area, volume, velocity, angular rate, and other derived quantities
 - Built-in astronomy-oriented units such as `AstronomicalUnit`, `LightYear`, `Parsec`, `SolarMass`, and `SolarLuminosity`
 - `no_std` support, optional `serde`, optional PyO3/SQL integrations, and integer scalar families
 
@@ -71,10 +71,23 @@ assert!((speed.value() - 10.0).abs() < 1e-12);
 ## Modules
 
 - `angular`, `time`, `length`, `mass`, `power`
-- `area`, `volume`
-- `velocity`, `frequency`
+- `area`, `volume`, `acceleration`, `force`, `energy`
+- `velocity`, `angular_rate`, `accel`
 - `unitless`
 - scalar-specific facades: `f32`, `f64`, `i8`, `i16`, `i32`, `i64`, `i128`
+
+## Custom units
+
+`qtty` re-exports the derive and arithmetic macros needed for downstream custom
+units, so most consumers do not need to depend on `qtty-core` directly.
+
+```rust
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd, qtty::Unit)]
+#[unit(crate = qtty, symbol = "smoot", dimension = qtty::Length, ratio = 1.7018)]
+pub struct Smoot;
+
+qtty::impl_unit_arithmetic_pairs_between!(qtty::unit::Meter, qtty::unit::Kilometer; Smoot);
+```
 
 ## Examples
 

--- a/qtty/examples/all_units.rs
+++ b/qtty/examples/all_units.rs
@@ -21,7 +21,7 @@
 //! cargo run -p qtty --example all_units
 //! ```
 
-use qtty::frequency::AngularRate;
+use qtty::angular_rate::AngularRate;
 use qtty::velocity::Velocity;
 use qtty::{
     AstronomicalUnit, CubicMeter, Kilogram, Kilometer, LightYear, Meter, Radian, Second,

--- a/qtty/src/f32.rs
+++ b/qtty/src/f32.rs
@@ -3,9 +3,9 @@
 
 //! Re-exports of quantity types specialized to `f32` scalar.
 //!
-//! This module provides type aliases for all unit types using `f32` as the
-//! underlying scalar type. Use this when memory efficiency is more important
-//! than precision.
+//! This module provides type aliases for all built-in unit types using `f32`
+//! as the underlying scalar type. Use this when memory efficiency is more
+//! important than precision.
 //!
 //! # Example
 //!
@@ -19,13 +19,9 @@
 
 macro_rules! _alias {
     ($($unit:ident),+ $(,)?) => {
-        $(pub type $unit<S = f32> = $crate::Quantity<$crate::unit::$unit, S>;)+
+        $(pub type $unit = $crate::Quantity<$crate::unit::$unit, f32>;)+
     };
 }
-qtty_core::angular_units!(_alias);
-qtty_core::length_units!(_alias);
-qtty_core::time_units!(_alias);
-qtty_core::mass_units!(_alias);
-qtty_core::power_units!(_alias);
-qtty_core::area_units!(_alias);
-qtty_core::volume_units!(_alias);
+
+crate::__qtty_invoke_all_inventories!(_alias);
+crate::__qtty_invoke_optional_inventories!(_alias);

--- a/qtty/src/f64.rs
+++ b/qtty/src/f64.rs
@@ -3,9 +3,10 @@
 
 //! Re-exports of quantity types specialized to `f64` scalar (default).
 //!
-//! This module provides type aliases for all unit types using `f64` as the
-//! underlying scalar type. These are identical to the types exported at the
-//! crate root, but are provided for symmetry with the [`crate::f32`] module.
+//! This module provides type aliases for all built-in unit types using `f64`
+//! as the underlying scalar type. These are identical to the default `f64`
+//! specializations exported at the crate root, but are provided for symmetry
+//! with the other scalar modules.
 //!
 //! # Example
 //!
@@ -19,13 +20,9 @@
 
 macro_rules! _alias {
     ($($unit:ident),+ $(,)?) => {
-        $(pub type $unit<S = f64> = $crate::Quantity<$crate::unit::$unit, S>;)+
+        $(pub type $unit = $crate::Quantity<$crate::unit::$unit, f64>;)+
     };
 }
-qtty_core::angular_units!(_alias);
-qtty_core::length_units!(_alias);
-qtty_core::time_units!(_alias);
-qtty_core::mass_units!(_alias);
-qtty_core::power_units!(_alias);
-qtty_core::area_units!(_alias);
-qtty_core::volume_units!(_alias);
+
+crate::__qtty_invoke_all_inventories!(_alias);
+crate::__qtty_invoke_optional_inventories!(_alias);

--- a/qtty/src/i128.rs
+++ b/qtty/src/i128.rs
@@ -22,13 +22,9 @@
 
 macro_rules! _alias {
     ($($unit:ident),+ $(,)?) => {
-        $(pub type $unit<S = i128> = $crate::Quantity<$crate::unit::$unit, S>;)+
+        $(pub type $unit = $crate::Quantity<$crate::unit::$unit, i128>;)+
     };
 }
-qtty_core::angular_units!(_alias);
-qtty_core::length_units!(_alias);
-qtty_core::time_units!(_alias);
-qtty_core::mass_units!(_alias);
-qtty_core::power_units!(_alias);
-qtty_core::area_units!(_alias);
-qtty_core::volume_units!(_alias);
+
+crate::__qtty_invoke_all_inventories!(_alias);
+crate::__qtty_invoke_optional_inventories!(_alias);

--- a/qtty/src/i16.rs
+++ b/qtty/src/i16.rs
@@ -22,13 +22,9 @@
 
 macro_rules! _alias {
     ($($unit:ident),+ $(,)?) => {
-        $(pub type $unit<S = i16> = $crate::Quantity<$crate::unit::$unit, S>;)+
+        $(pub type $unit = $crate::Quantity<$crate::unit::$unit, i16>;)+
     };
 }
-qtty_core::angular_units!(_alias);
-qtty_core::length_units!(_alias);
-qtty_core::time_units!(_alias);
-qtty_core::mass_units!(_alias);
-qtty_core::power_units!(_alias);
-qtty_core::area_units!(_alias);
-qtty_core::volume_units!(_alias);
+
+crate::__qtty_invoke_all_inventories!(_alias);
+crate::__qtty_invoke_optional_inventories!(_alias);

--- a/qtty/src/i32.rs
+++ b/qtty/src/i32.rs
@@ -22,13 +22,9 @@
 
 macro_rules! _alias {
     ($($unit:ident),+ $(,)?) => {
-        $(pub type $unit<S = i32> = $crate::Quantity<$crate::unit::$unit, S>;)+
+        $(pub type $unit = $crate::Quantity<$crate::unit::$unit, i32>;)+
     };
 }
-qtty_core::angular_units!(_alias);
-qtty_core::length_units!(_alias);
-qtty_core::time_units!(_alias);
-qtty_core::mass_units!(_alias);
-qtty_core::power_units!(_alias);
-qtty_core::area_units!(_alias);
-qtty_core::volume_units!(_alias);
+
+crate::__qtty_invoke_all_inventories!(_alias);
+crate::__qtty_invoke_optional_inventories!(_alias);

--- a/qtty/src/i64.rs
+++ b/qtty/src/i64.rs
@@ -22,13 +22,9 @@
 
 macro_rules! _alias {
     ($($unit:ident),+ $(,)?) => {
-        $(pub type $unit<S = i64> = $crate::Quantity<$crate::unit::$unit, S>;)+
+        $(pub type $unit = $crate::Quantity<$crate::unit::$unit, i64>;)+
     };
 }
-qtty_core::angular_units!(_alias);
-qtty_core::length_units!(_alias);
-qtty_core::time_units!(_alias);
-qtty_core::mass_units!(_alias);
-qtty_core::power_units!(_alias);
-qtty_core::area_units!(_alias);
-qtty_core::volume_units!(_alias);
+
+crate::__qtty_invoke_all_inventories!(_alias);
+crate::__qtty_invoke_optional_inventories!(_alias);

--- a/qtty/src/i8.rs
+++ b/qtty/src/i8.rs
@@ -22,13 +22,9 @@
 
 macro_rules! _alias {
     ($($unit:ident),+ $(,)?) => {
-        $(pub type $unit<S = i8> = $crate::Quantity<$crate::unit::$unit, S>;)+
+        $(pub type $unit = $crate::Quantity<$crate::unit::$unit, i8>;)+
     };
 }
-qtty_core::angular_units!(_alias);
-qtty_core::length_units!(_alias);
-qtty_core::time_units!(_alias);
-qtty_core::mass_units!(_alias);
-qtty_core::power_units!(_alias);
-qtty_core::area_units!(_alias);
-qtty_core::volume_units!(_alias);
+
+crate::__qtty_invoke_all_inventories!(_alias);
+crate::__qtty_invoke_optional_inventories!(_alias);

--- a/qtty/src/lib.rs
+++ b/qtty/src/lib.rs
@@ -86,7 +86,8 @@
 //! `qtty::unit` for generic APIs such as `Quantity<U, S>` and `Velocity<N, D>`:
 //!
 //! - `qtty::velocity` (`Length / Time` aliases)
-//! - `qtty::frequency` (`Angular / Time` aliases)
+//! - `qtty::angular_rate` (`Angular / Time` aliases)
+//! - `qtty::acceleration`, `qtty::force`, `qtty::energy`
 //! - `qtty::unit` (type-level unit markers)
 //! - `qtty::f32` (all units with `f32` scalar)
 //! - `qtty::f64` (all units with `f64` scalar - same as root)
@@ -103,6 +104,28 @@
 //! - `alloc`: enables heap-backed helpers (like `qtty_vec!(vec ...)`) in `no_std` builds.
 //! - `serde`: enables `serde` support for `Quantity<U, S>`; serialization is the raw scalar value.
 //! - `scalar-rational`: enables `num_rational::Rational64` as a scalar type.
+//!
+//! # Custom Units
+//!
+//! `qtty` re-exports the derive macro plus the arithmetic/conversion macros
+//! from `qtty-core`, so downstream crates can define units without depending on
+//! `qtty-core` directly:
+//!
+//! ```ignore
+//! #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, qtty::Unit)]
+//! #[unit(crate = qtty, symbol = "smoot", dimension = qtty::Length, ratio = 1.7018)]
+//! pub struct Smoot;
+//!
+//! qtty::impl_unit_arithmetic_pairs_between!(qtty::unit::Meter, qtty::unit::Kilometer; Smoot);
+//! ```
+//!
+//! ## Limitations of downstream units
+//!
+//! Custom units participate in arithmetic (`*`, `/`) and `From`-based
+//! conversion via the macro registrations shown above.  However, due to Rust's
+//! orphan rules, the derive macro cannot generate `Display`/`LowerExp`/`UpperExp`
+//! impls for `Quantity<CustomUnit, S>` from a downstream crate.  Downstream
+//! units must implement formatting manually if needed.
 //!
 //! Disable default features for `no_std`:
 //!
@@ -128,6 +151,18 @@
 //! # SemVer and stability
 //!
 //! This workspace is currently `0.x`. Expect breaking changes between minor versions until `1.0`.
+//!
+//! The following items are **explicitly excluded from the semver guarantee**
+//! even though they appear in the compiled crate:
+//!
+//! - [`Dim`], [`DimDiv`], [`DimMul`] — typenum-driven dimension markers used
+//!   internally by `impl_unit_*` macros.  Their shape will change if the
+//!   underlying numeric representation is ever replaced.
+//! - [`UnitDiv`], [`UnitMul`] — arithmetic-layer traits whose associated-type
+//!   signatures depend on the dimension representation above.
+//!
+//! All five are marked `#[doc(hidden)]`.  Do not depend on their concrete
+//! types in downstream code.
 #![cfg_attr(not(feature = "std"), no_std)]
 #![forbid(unsafe_code)]
 
@@ -135,15 +170,43 @@
 extern crate alloc;
 
 pub use qtty_core::{
+    impl_unit_arithmetic_pairs, impl_unit_arithmetic_pairs_between, impl_unit_cross_unit_ops,
+    impl_unit_cross_unit_ops_between, impl_unit_division_pairs, impl_unit_division_pairs_between,
+    impl_unit_from_conversions, impl_unit_from_conversions_between, impl_unit_multiplication_pairs,
+    impl_unit_multiplication_pairs_between,
+};
+pub use qtty_core::{
     Acceleration, AmountOfSubstance, Angular, AngularRate, Area, Current, Dimension, Dimensionless,
     Energy, Exact, Force, IntegerScalar, Length, LuminousIntensity, Mass, Per, Power, Prod,
     Quantity, Quantity32, Quantity64, QuantityI128, QuantityI16, QuantityI32, QuantityI64,
-    QuantityI8, Real, Scalar, Temperature, Time, Transcendental, Unit, UnitDiv, UnitMul, Velocity,
-    Volume,
+    QuantityI8, Real, Scalar, Temperature, Time, Transcendental, Unit, Velocity, Volume,
 };
 
+// `UnitDiv`, `UnitMul`, and the dimension-level traits are needed by the
+// `impl_unit_*` macros when they expand in downstream crates.  They are
+// also useful for writing generic code, but their associated types expose
+// typenum-based dimension markers.
+//
+// # Stability note
+//
+// `Dim`, `DimDiv`, `DimMul`, `UnitDiv`, and `UnitMul` are **excluded from
+// the semver stability guarantee** of this crate even though they are
+// technically re-exported.  They are marked `#[doc(hidden)]` because they
+// are implementation details of the macro-generated arithmetic layer.
+// Specifically:
+//
+// * `Dim` and its `DimDiv`/`DimMul` associated types are driven by
+//   `typenum` integers.  Replacing `typenum` would be a breaking change to
+//   these types, and that replacement is not considered a breaking change
+//   for `qtty`'s public API.
+// * The `impl_unit_*` macros re-export these at their expansion sites so
+//   downstream users are never expected to name them directly.
+//
+// If you find yourself writing `use qtty::{Dim, DimDiv, DimMul}` in
+// application code, consider opening an issue — that is a sign of a missing
+// ergonomic abstraction in the public API.
 #[doc(hidden)]
-pub use qtty_core::{Dim, DimDiv, DimMul};
+pub use qtty_core::{Dim, DimDiv, DimMul, UnitDiv, UnitMul};
 
 #[cfg(feature = "scalar-rational")]
 pub use qtty_core::QuantityRational;
@@ -154,10 +217,21 @@ pub use qtty_core::serde_with_unit;
 #[cfg(feature = "serde")]
 pub use qtty_core::serde_scalar;
 
-/// Derive macro used by `qtty-core` to define unit marker types.
+/// Derive macro used to define unit marker types.
 ///
-/// This macro expands in terms of `crate::Unit` and `crate::Quantity`, so it is intended for use inside `qtty-core`
-/// (or crates exposing the same crate-root API). Most users should not need this.
+/// Inside `qtty-core`, `#[derive(Unit)]` works with the default
+/// `#[unit(symbol = ..., dimension = ..., ratio = ...)]` form. Downstream crates
+/// should target the public facade explicitly:
+///
+/// ```ignore
+/// #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, qtty::Unit)]
+/// #[unit(crate = qtty, symbol = "smoot", dimension = qtty::Length, ratio = 1.7018)]
+/// pub struct Smoot;
+/// ```
+///
+/// Pair this with `qtty::impl_unit_arithmetic_pairs!` or
+/// `qtty::impl_unit_arithmetic_pairs_between!` when you want custom units to
+/// participate in `*` and `/` result-type inference.
 pub use qtty_derive::Unit;
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -169,7 +243,9 @@ pub use qtty_derive::Unit;
 /// The callback is invoked once per dimension (8 total). This is usable for
 /// additive generation (aliases, assertions) where the callback doesn't need
 /// to know which dimension/module the units come from.
-macro_rules! invoke_all_inventories {
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __qtty_invoke_all_inventories {
     ($cb:path) => {
         qtty_core::angular_units!($cb);
         qtty_core::length_units!($cb);
@@ -188,7 +264,9 @@ macro_rules! invoke_all_inventories {
 ///
 /// This keeps the crate-root quantity aliases aligned with the unit markers
 /// re-exported from [`crate::unit`] whenever optional unit families are enabled.
-macro_rules! invoke_optional_inventories {
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __qtty_invoke_optional_inventories {
     ($cb:path) => {
         #[cfg(feature = "astro")]
         qtty_core::angular_astro_units!($cb);
@@ -382,9 +460,13 @@ pub mod velocity {
     pub use qtty_core::units::velocity::{Velocity, VelocityUnit};
 }
 
-/// Angular-rate quantities represented as one unit divided by another.
-pub mod frequency {
-    pub use qtty_core::units::frequency::{AngularRate, AngularRateUnit};
+/// Angular-rate quantities represented as one unit divided by another (`Angular / Time`).
+///
+/// This module models angular displacement per unit time (e.g. rad/s, deg/day).
+/// It does **not** model SI Hertz-style inverse-time frequency (`T⁻¹`); see
+/// [`qtty_core::angular_rate`] for the distinction.
+pub mod angular_rate {
+    pub use qtty_core::units::angular_rate::{AngularRate, AngularRateUnit};
 }
 
 /// Acceleration quantities represented as `Length / Time²`.
@@ -404,8 +486,8 @@ macro_rules! _root_alias {
         )+
     };
 }
-invoke_all_inventories!(_root_alias);
-invoke_optional_inventories!(_root_alias);
+__qtty_invoke_all_inventories!(_root_alias);
+__qtty_invoke_optional_inventories!(_root_alias);
 
 /// Dimensionless quantity alias.
 pub type Unitless<S = f64> = Quantity<unit::Unitless, S>;

--- a/qtty/tests/custom_unit_extensions.rs
+++ b/qtty/tests/custom_unit_extensions.rs
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Vallés Puig, Ramon
+
+//! Downstream-style custom unit tests using only the public `qtty` facade.
+
+use qtty::{Meter, Quantity};
+
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd, qtty::Unit)]
+#[unit(crate = qtty, symbol = "smoot", dimension = qtty::Length, ratio = 1.7018)]
+pub struct Smoot;
+
+pub type Smoots = Quantity<Smoot>;
+
+qtty::impl_unit_arithmetic_pairs_between!(qtty::unit::Meter, qtty::unit::Kilometer; Smoot);
+
+#[test]
+fn downstream_custom_unit_can_convert_to_builtins() {
+    let smoot = Smoots::new(1.0);
+    let meters: Meter = smoot.to();
+    assert!((meters.value() - 1.7018).abs() < 1e-12);
+}
+
+#[test]
+fn downstream_custom_unit_divides_with_builtins() {
+    let meters = Meter::new(10.0);
+    let smoots = Smoots::new(2.0);
+    let ratio: Quantity<qtty::Per<qtty::unit::Meter, Smoot>> = meters / smoots;
+    assert!((ratio.value() - 5.0).abs() < 1e-12);
+}
+
+#[test]
+fn downstream_custom_unit_multiplies_with_builtins() {
+    let smoots = Smoots::new(2.0);
+    let meters = Meter::new(3.0);
+    let product: Quantity<qtty::Prod<Smoot, qtty::unit::Meter>> = smoots * meters;
+    assert!((product.value() - 6.0).abs() < 1e-12);
+}

--- a/qtty/tests/integration_tests.rs
+++ b/qtty/tests/integration_tests.rs
@@ -53,10 +53,10 @@ fn smoke_test_velocity() {
 }
 
 #[test]
-fn smoke_test_frequency() {
-    let f: frequency::AngularRate<qtty::unit::Degree, qtty::unit::Day> =
-        frequency::AngularRate::new(360.0);
-    let f_rad: frequency::AngularRate<qtty::unit::Radian, qtty::unit::Day> = f.to();
+fn smoke_test_angular_rate() {
+    let f: angular_rate::AngularRate<qtty::unit::Degree, qtty::unit::Day> =
+        angular_rate::AngularRate::new(360.0);
+    let f_rad: angular_rate::AngularRate<qtty::unit::Radian, qtty::unit::Day> = f.to();
     assert_abs_diff_eq!(f_rad.value(), 2.0 * std::f64::consts::PI, epsilon = 1e-12);
 }
 
@@ -121,8 +121,8 @@ fn angular_separation() {
 #[test]
 fn earth_rotation() {
     // Earth rotates 360° per sidereal day (~23h 56m)
-    let rotation_rate: frequency::AngularRate<qtty::unit::Degree, qtty::unit::Day> =
-        frequency::AngularRate::new(360.0);
+    let rotation_rate: angular_rate::AngularRate<qtty::unit::Degree, qtty::unit::Day> =
+        angular_rate::AngularRate::new(360.0);
 
     // After 6 hours (0.25 days)
     let time = Day::new(0.25);
@@ -174,11 +174,12 @@ fn calculate_velocity_from_distance_time() {
 #[test]
 fn mean_motion_conversion() {
     // Earth's mean motion ≈ 0.9856°/day
-    let mean_motion: frequency::AngularRate<qtty::unit::Degree, qtty::unit::Day> =
-        frequency::AngularRate::new(0.9856);
+    let mean_motion: angular_rate::AngularRate<qtty::unit::Degree, qtty::unit::Day> =
+        angular_rate::AngularRate::new(0.9856);
 
     // Convert to degrees per year
-    let per_year: frequency::AngularRate<qtty::unit::Degree, qtty::unit::Year> = mean_motion.to();
+    let per_year: angular_rate::AngularRate<qtty::unit::Degree, qtty::unit::Year> =
+        mean_motion.to();
 
     // Should be about 360°/year
     assert_relative_eq!(per_year.value(), 360.0, max_relative = 0.01);

--- a/qtty/tests/inventory_consistency.rs
+++ b/qtty/tests/inventory_consistency.rs
@@ -6,13 +6,15 @@
 //!
 //! ## What this checks
 //!
-//! Two invariants are enforced at compile time:
+//! Several invariants are enforced at compile time:
 //!
 //! 1. **Unit marker re-exports** (`qtty::unit::*`): every unit in a dimension
 //!    inventory is re-exported from `pub mod unit { ... }` in `qtty/src/lib.rs`.
 //! 2. **Scalar quantity aliases** (`qtty::*`): every unit in a dimension
 //!    inventory has a corresponding `pub type $name<S = f64>` alias generated
-//!    by `define_scalar_aliases!` in `qtty/src/scalar_aliases.rs`.
+//!    at the crate root in `qtty/src/lib.rs`.
+//! 3. **Scalar modules** (`qtty::f32::*`, `qtty::i32::*`, etc.): every unit in
+//!    the public inventory is available from each scalar-specific facade.
 //!
 //! ## How it works
 //!
@@ -25,8 +27,7 @@
 //! ## What to do when this fails
 //!
 //! Add the missing unit to the appropriate `pub use qtty_core::units::dim::...`
-//! block in `lib.rs`, or add the missing `pub type $name` alias to the
-//! `define_scalar_aliases!` macro in `scalar_aliases.rs`.
+//! block in `lib.rs`, or fix the alias-generation macros in `qtty/src/lib.rs`.
 
 /// Assert that every listed unit name resolves as `qtty::unit::$name`
 /// (marker struct re-export).
@@ -52,22 +53,99 @@ macro_rules! assert_alias_exists {
     };
 }
 
+macro_rules! assert_f32_alias_exists {
+    ($($name:ident),+ $(,)?) => {
+        $(
+            const _: () = {
+                fn _check(_: qtty::f32::$name) {}
+            };
+        )+
+    };
+}
+
+macro_rules! assert_f64_alias_exists {
+    ($($name:ident),+ $(,)?) => {
+        $(
+            const _: () = {
+                fn _check(_: qtty::f64::$name) {}
+            };
+        )+
+    };
+}
+
+macro_rules! assert_i8_alias_exists {
+    ($($name:ident),+ $(,)?) => {
+        $(
+            const _: () = {
+                fn _check(_: qtty::i8::$name) {}
+            };
+        )+
+    };
+}
+
+macro_rules! assert_i16_alias_exists {
+    ($($name:ident),+ $(,)?) => {
+        $(
+            const _: () = {
+                fn _check(_: qtty::i16::$name) {}
+            };
+        )+
+    };
+}
+
+macro_rules! assert_i32_alias_exists {
+    ($($name:ident),+ $(,)?) => {
+        $(
+            const _: () = {
+                fn _check(_: qtty::i32::$name) {}
+            };
+        )+
+    };
+}
+
+macro_rules! assert_i64_alias_exists {
+    ($($name:ident),+ $(,)?) => {
+        $(
+            const _: () = {
+                fn _check(_: qtty::i64::$name) {}
+            };
+        )+
+    };
+}
+
+macro_rules! assert_i128_alias_exists {
+    ($($name:ident),+ $(,)?) => {
+        $(
+            const _: () = {
+                fn _check(_: qtty::i128::$name) {}
+            };
+        )+
+    };
+}
+
 // ── Unit marker re-exports (qtty::unit::*) ──────────────────────────────────
 
-qtty_core::angular_units!(assert_unit_reexported);
-qtty_core::length_units!(assert_unit_reexported);
-qtty_core::time_units!(assert_unit_reexported);
-qtty_core::mass_units!(assert_unit_reexported);
-qtty_core::power_units!(assert_unit_reexported);
-qtty_core::area_units!(assert_unit_reexported);
-qtty_core::volume_units!(assert_unit_reexported);
+qtty::__qtty_invoke_all_inventories!(assert_unit_reexported);
+qtty::__qtty_invoke_optional_inventories!(assert_unit_reexported);
 
 // ── Scalar quantity aliases (qtty::*) ───────────────────────────────────────
 
-qtty_core::angular_units!(assert_alias_exists);
-qtty_core::length_units!(assert_alias_exists);
-qtty_core::time_units!(assert_alias_exists);
-qtty_core::mass_units!(assert_alias_exists);
-qtty_core::power_units!(assert_alias_exists);
-qtty_core::area_units!(assert_alias_exists);
-qtty_core::volume_units!(assert_alias_exists);
+qtty::__qtty_invoke_all_inventories!(assert_alias_exists);
+qtty::__qtty_invoke_optional_inventories!(assert_alias_exists);
+
+// ── Scalar module aliases (qtty::f32::*, qtty::i8::*, …) ───────────────────
+
+qtty::__qtty_invoke_all_inventories!(assert_f32_alias_exists);
+qtty::__qtty_invoke_optional_inventories!(assert_f32_alias_exists);
+qtty::__qtty_invoke_all_inventories!(assert_f64_alias_exists);
+qtty::__qtty_invoke_optional_inventories!(assert_f64_alias_exists);
+qtty::__qtty_invoke_all_inventories!(assert_i8_alias_exists);
+qtty::__qtty_invoke_optional_inventories!(assert_i8_alias_exists);
+qtty::__qtty_invoke_all_inventories!(assert_i16_alias_exists);
+qtty::__qtty_invoke_optional_inventories!(assert_i16_alias_exists);
+qtty::__qtty_invoke_all_inventories!(assert_i32_alias_exists);
+qtty::__qtty_invoke_optional_inventories!(assert_i32_alias_exists);
+qtty::__qtty_invoke_all_inventories!(assert_i64_alias_exists);
+qtty::__qtty_invoke_optional_inventories!(assert_i64_alias_exists);
+qtty::__qtty_invoke_all_inventories!(assert_i128_alias_exists);
+qtty::__qtty_invoke_optional_inventories!(assert_i128_alias_exists);


### PR DESCRIPTION
- Fix f32 to_const precision: perform RATIO division in f64 before cast
- Update CODATA 2018 → 2022 for Bohr radius, classical electron radius, and reduced Compton wavelength (NIST recommended values)
- Add DAYS_PER_GREGORIAN_YEAR constant, replace 4 literal occurrences
- Add MulAssign<S> for Quantity (symmetric with existing DivAssign<S>)
- Add Rem<Quantity<U,S>> for same-unit remainder (5 m % 3 m == 2 m)
- Update affected tests for new CODATA 2022 expected values
- Record all changes in CHANGELOG.md [Unreleased]