### PR TITLE
Add quantity-level rounding helpers and clamp method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,14 @@ All notable changes to this project are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - yyyy-mm-dd
+## [Unreleased] - 2026-04-15
 
 ### Added
+
+- **Quantity-level real-number rounding helpers** (`qtty-core`, re-exported by
+  `qtty`) — `Quantity<U, S>` for `S: Real` now exposes `floor()`, `ceil()`,
+  `round()`, `trunc()`, and `fract()`, matching the scalar `Real` surface while
+  preserving unit types through common rounding workflows.
 
 - **`assert_units_are_builtin!`** (`qtty-core`, `#[doc(hidden)]`) — compile-time
   assertion macro driven by each dimension's inventory macro under `#[cfg(test)]`.
@@ -75,6 +80,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and
 - **Breaking:** Removed deprecated `Quantity<Unitless>::asin()`, `acos()`, and `atan()` scalar-returning methods. Use `asin_angle()`, `acos_angle()`, and `atan_angle()` instead.
 
 ### Changed
+- Downstream crates can now keep more rounding and timestamp-normalization logic
+  in typed quantities instead of erasing units to raw floating-point values for
+  `floor`/`ceil`/`round`/fractional extraction.
+
 - **CODATA 2018 → 2022** (`fundamental-physics`) — Updated Bohr radius,
   classical electron radius, and electron reduced Compton wavelength to the
   CODATA 2022 recommended values. Planck length and atomic mass unit are

--- a/qtty-core/src/quantity.rs
+++ b/qtty-core/src/quantity.rs
@@ -329,10 +329,34 @@ impl<U: Unit, S: Real> Quantity<U, S> {
         self.0.sqrt()
     }
 
+    /// Returns the largest integer quantity less than or equal to this value.
+    #[inline]
+    pub fn floor(self) -> Self {
+        Self::new(self.0.floor())
+    }
+
     /// Returns the smallest integer quantity greater than or equal to this value.
     #[inline]
     pub fn ceil(self) -> Self {
         Self::new(self.0.ceil())
+    }
+
+    /// Returns the nearest integer quantity to this value.
+    #[inline]
+    pub fn round(self) -> Self {
+        Self::new(self.0.round())
+    }
+
+    /// Returns the integer part of this quantity.
+    #[inline]
+    pub fn trunc(self) -> Self {
+        Self::new(self.0.trunc())
+    }
+
+    /// Returns the fractional part of this quantity.
+    #[inline]
+    pub fn fract(self) -> Self {
+        Self::new(self.0.fract())
     }
 
     /// Checks equality with a quantity of a different unit in the same dimension.

--- a/qtty-core/src/quantity.rs
+++ b/qtty-core/src/quantity.rs
@@ -142,6 +142,12 @@ impl<U: Unit, S: Scalar> Quantity<U, S> {
         Self::new(self.0.max(other.0))
     }
 
+    /// Clamps this quantity to `[min_val, max_val]`.
+    #[inline]
+    pub fn clamp(self, min_val: Self, max_val: Self) -> Self {
+        self.max(min_val).min(max_val)
+    }
+
     /// Returns the arithmetic mean (midpoint) of this quantity and another.
     ///
     /// For integer-backed quantities this uses integer division semantics

--- a/qtty-core/tests/core.rs
+++ b/qtty-core/tests/core.rs
@@ -62,6 +62,32 @@ fn quantity_ceil() {
 }
 
 #[test]
+fn quantity_floor() {
+    assert_eq!(TU::new(3.7).floor().value(), 3.0);
+    assert_eq!(TU::new(-3.7).floor().value(), -4.0);
+    assert_eq!(TU::new(5.0).floor().value(), 5.0);
+}
+
+#[test]
+fn quantity_round() {
+    assert_eq!(TU::new(3.5).round().value(), 4.0);
+    assert_eq!(TU::new(3.4).round().value(), 3.0);
+    assert_eq!(TU::new(-3.5).round().value(), -4.0);
+}
+
+#[test]
+fn quantity_trunc() {
+    assert_eq!(TU::new(3.9).trunc().value(), 3.0);
+    assert_eq!(TU::new(-3.9).trunc().value(), -3.0);
+}
+
+#[test]
+fn quantity_fract() {
+    assert!((TU::new(3.75).fract().value() - 0.75).abs() < 1e-12);
+    assert!((TU::new(-3.75).fract().value() + 0.75).abs() < 1e-12);
+}
+
+#[test]
 fn quantity_from_f64() {
     let q: TU = 123.456.into();
     assert_eq!(q.value(), 123.456);

--- a/qtty-core/tests/quantity_f32.rs
+++ b/qtty-core/tests/quantity_f32.rs
@@ -136,6 +136,32 @@ fn f32_quantity_ceil() {
 }
 
 #[test]
+fn f32_quantity_floor() {
+    assert_eq!(TU32::new(3.7).floor().value(), 3.0_f32);
+    assert_eq!(TU32::new(-3.7).floor().value(), -4.0_f32);
+    assert_eq!(TU32::new(5.0).floor().value(), 5.0_f32);
+}
+
+#[test]
+fn f32_quantity_round() {
+    assert_eq!(TU32::new(3.5).round().value(), 4.0_f32);
+    assert_eq!(TU32::new(3.4).round().value(), 3.0_f32);
+    assert_eq!(TU32::new(-3.5).round().value(), -4.0_f32);
+}
+
+#[test]
+fn f32_quantity_trunc() {
+    assert_eq!(TU32::new(3.9).trunc().value(), 3.0_f32);
+    assert_eq!(TU32::new(-3.9).trunc().value(), -3.0_f32);
+}
+
+#[test]
+fn f32_quantity_fract() {
+    assert!((TU32::new(3.75).fract().value() - 0.75).abs() < 1e-6);
+    assert!((TU32::new(-3.75).fract().value() + 0.75).abs() < 1e-6);
+}
+
+#[test]
 fn f32_quantity_cast() {
     let q = TU32::new(42.5);
     let q_f64: Quantity<TestUnit, f64> = q.cast();


### PR DESCRIPTION
This pull request introduces new rounding helper methods for real-number quantities, allowing operations like `floor`, `ceil`, `round`, `trunc`, and `fract` to be performed directly on typed quantities while preserving their units. This enhancement makes it easier to perform rounding and normalization workflows without erasing unit information. The changes also include a new `clamp` method for quantities and comprehensive tests for the added functionality.

### New rounding and clamping methods for quantities

* Added `floor()`, `ceil()`, `round()`, `trunc()`, and `fract()` methods to `Quantity<U, S>` where `S: Real`, allowing unit-preserving rounding operations.
* Introduced a `clamp()` method to `Quantity<U, S>` for bounding values within a specified range.

### Improved documentation and changelog

* Updated the changelog to document the new rounding helpers and clarify that downstream crates can now keep more rounding logic in typed quantities. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL8-R16) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR83-R86)

### Comprehensive testing

* Added tests for all new rounding methods (`floor`, `ceil`, `round`, `trunc`, `fract`) for both default and `f32`-backed quantities in `qtty-core/tests/core.rs` and `qtty-core/tests/quantity_f32.rs`. [[1]](diffhunk://#diff-953609e35ff0ad3dc9fda802d6031d70f25217f22e48df1561e9f299ff57a226R64-R89) [[2]](diffhunk://#diff-224362f05a19ee2dd47716c834867b2236e392cee5cd59fa50de87e1b5a49f2eR138-R163)