### PR TITLE
Enhance Quantity with Hash implementation and clamp method tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ resolver = "2"
 [workspace.package]
 version = "0.5.0"
 edition = "2021"
+rust-version = "1.82"
 authors = ["VPRamon <vallespuigramon@gmail.com>"]
 license = "AGPL-3.0"
 repository = "https://github.com/Siderust/qtty"

--- a/qtty-core/src/quantity.rs
+++ b/qtty-core/src/quantity.rs
@@ -7,6 +7,7 @@ use crate::scalar::{Exact, Real, Scalar, Transcendental};
 use crate::unit::Unit;
 use crate::unit_arithmetic::{QuantityDivOutput, UnitDiv, UnitMul};
 use core::cmp::Ordering;
+use core::hash::{Hash, Hasher};
 use core::iter::Sum;
 use core::marker::PhantomData;
 use core::ops::*;
@@ -145,6 +146,10 @@ impl<U: Unit, S: Scalar> Quantity<U, S> {
     /// Clamps this quantity to `[min_val, max_val]`.
     #[inline]
     pub fn clamp(self, min_val: Self, max_val: Self) -> Self {
+        debug_assert!(
+            min_val.0 <= max_val.0,
+            "Quantity::clamp requires min_val <= max_val"
+        );
         self.max(min_val).min(max_val)
     }
 
@@ -857,6 +862,14 @@ impl<U: Unit, S: Scalar> PartialOrd for Quantity<U, S> {
 
 // Eq for scalar types that support total equality (integers, rationals, decimals)
 impl<U: Unit, S: Scalar + Eq> Eq for Quantity<U, S> {}
+
+// Hash for scalar types that support hashing, enabling Quantity in HashMap/HashSet.
+impl<U: Unit, S: Scalar + Hash> Hash for Quantity<U, S> {
+    #[inline]
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.hash(state);
+    }
+}
 
 // Ord for scalar types that support total ordering (integers, rationals, decimals)
 impl<U: Unit, S: Scalar + Ord> Ord for Quantity<U, S> {

--- a/qtty-core/src/unit.rs
+++ b/qtty-core/src/unit.rs
@@ -16,6 +16,10 @@ use core::marker::PhantomData;
 ///   because `1 km = 1000 m`.
 ///
 /// * `SYMBOL` is the printable string (e.g. `"m"` or `"km"`).
+///   For some composite generic units (such as [`Per`] and [`Prod`]), this is
+///   currently an empty string because Rust does not yet support composing
+///   generic unit symbols as a `const`. Use `Display`/`LowerExp`/`UpperExp` on
+///   [`Quantity`] for user-facing formatting of composite units.
 ///
 /// * `Dim` ties the unit to its underlying [`Dimension`].
 ///
@@ -62,6 +66,8 @@ where
 {
     const RATIO: f64 = N::RATIO / D::RATIO;
     type Dim = <N::Dim as DimDiv<D::Dim>>::Output;
+    // Generic const-string composition is not yet available; formatted symbols
+    // are provided by Display/LowerExp/UpperExp impls for Quantity<Per<...>, S>.
     const SYMBOL: &'static str = "";
 }
 
@@ -113,6 +119,8 @@ where
 {
     const RATIO: f64 = A::RATIO * B::RATIO;
     type Dim = <A::Dim as DimMul<B::Dim>>::Output;
+    // Generic const-string composition is not yet available; formatted symbols
+    // are provided by Display/LowerExp/UpperExp impls for Quantity<Prod<...>, S>.
     const SYMBOL: &'static str = "";
 }
 

--- a/qtty-core/src/units/angular/mod.rs
+++ b/qtty-core/src/units/angular/mod.rs
@@ -312,7 +312,8 @@ impl Degrees {
 
     /// Construct from explicit sign and magnitude components.
     ///
-    /// `sign` should be −1, 0, or +1 (0 treated as +1 unless all components are zero).
+    /// `sign < 0` produces a negative result; any other value (including `0`)
+    /// produces a positive result.
     pub const fn from_dms_sign(sign: i8, deg: u32, min: u32, sec: f64) -> Self {
         let s = if sign < 0 { -1.0 } else { 1.0 };
         let total = (deg as f64) + (min as f64) / 60.0 + (sec / 3600.0);
@@ -782,6 +783,12 @@ mod tests {
         let neg = Degrees::from_dms_sign(-1, 45, 30, 0.0);
         assert_abs_diff_eq!(pos.value(), 45.5, epsilon = 1e-12);
         assert_abs_diff_eq!(neg.value(), -45.5, epsilon = 1e-12);
+    }
+
+    #[test]
+    fn degrees_from_dms_sign_zero_is_positive() {
+        let zero_sign = Degrees::from_dms_sign(0, 45, 30, 0.0);
+        assert_abs_diff_eq!(zero_sign.value(), 45.5, epsilon = 1e-12);
     }
 
     #[test]

--- a/qtty-core/tests/core.rs
+++ b/qtty-core/tests/core.rs
@@ -152,6 +152,21 @@ fn const_min() {
 }
 
 #[test]
+fn quantity_clamp_with_valid_bounds() {
+    let q = TU::new(7.5);
+    assert_eq!(q.clamp(TU::new(0.0), TU::new(10.0)).value(), 7.5);
+    assert_eq!(q.clamp(TU::new(8.0), TU::new(10.0)).value(), 8.0);
+    assert_eq!(q.clamp(TU::new(0.0), TU::new(7.0)).value(), 7.0);
+}
+
+#[cfg(debug_assertions)]
+#[test]
+#[should_panic(expected = "Quantity::clamp requires min_val <= max_val")]
+fn quantity_clamp_panics_on_inverted_bounds_in_debug() {
+    let _ = TU::new(5.0).clamp(TU::new(10.0), TU::new(0.0));
+}
+
+#[test]
 fn operator_add() {
     let a = TU::new(3.0);
     let b = TU::new(7.0);

--- a/qtty-core/tests/integers.rs
+++ b/qtty-core/tests/integers.rs
@@ -10,6 +10,7 @@ use qtty_core::length::{Kilometer, Meter};
 use qtty_core::scalar::{Exact, IntegerScalar};
 use qtty_core::time::Second;
 use qtty_core::{Per, Quantity, QuantityI32, QuantityI64};
+use std::collections::{HashMap, HashSet};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Basic construction and value access
@@ -154,6 +155,20 @@ fn test_i64_rem() {
 fn test_i32_partial_eq_scalar() {
     let a = Quantity::<Meter, i32>::new(42);
     assert_eq!(a, Quantity::<Meter, i32>::new(42));
+}
+
+#[test]
+fn test_i32_quantity_hashmap_hashset_keys() {
+    let a = Quantity::<Meter, i32>::new(42);
+    let b = Quantity::<Meter, i32>::new(42);
+
+    let mut set = HashSet::new();
+    set.insert(a);
+    assert!(set.contains(&b));
+
+    let mut map = HashMap::new();
+    map.insert(a, "answer");
+    assert_eq!(map.get(&b), Some(&"answer"));
 }
 
 #[test]

--- a/qtty-ffi/src/helpers.rs
+++ b/qtty-ffi/src/helpers.rs
@@ -47,10 +47,10 @@
 //!
 //! ```rust
 //! use qtty::length::Meters;
-//! use qtty_ffi::{QttyQuantity, UnitId};
+//! use qtty_ffi::{QttyQuantity, QttyStatus, UnitId};
 //!
 //! let time_qty = QttyQuantity::new(60.0, UnitId::Second);
-//! let result: Result<Meters, i32> = time_qty.try_into();
+//! let result: Result<Meters, QttyStatus> = time_qty.try_into();
 //! assert!(result.is_err());
 //! ```
 
@@ -118,8 +118,8 @@ mod tests {
     fn test_incompatible_conversion_fails() {
         let meters = qtty::length::Meters::new(100.0);
         let ffi: QttyQuantity = meters.into();
-        let result: Result<qtty::time::Seconds, i32> = ffi.try_into();
-        assert_eq!(result, Err(QttyStatus::IncompatibleDim as i32));
+        let result: Result<qtty::time::Seconds, QttyStatus> = ffi.try_into();
+        assert_eq!(result, Err(QttyStatus::IncompatibleDim));
     }
 
     #[test]

--- a/qtty-ffi/src/macros.rs
+++ b/qtty-ffi/src/macros.rs
@@ -106,12 +106,12 @@ macro_rules! impl_unit_ffi {
         }
 
         impl core::convert::TryFrom<$crate::QttyQuantity> for $qty_type {
-            type Error = i32;
+            type Error = $crate::QttyStatus;
 
             #[inline]
             fn try_from(qty: $crate::QttyQuantity) -> Result<Self, Self::Error> {
-                let src_unit = $crate::UnitId::from_u32(qty.unit)
-                    .ok_or($crate::QttyStatus::UnknownUnit as i32)?;
+                let src_unit =
+                    $crate::UnitId::from_u32(qty.unit).ok_or($crate::QttyStatus::UnknownUnit)?;
 
                 // If already the right unit, just wrap
                 if src_unit == $unit_id {


### PR DESCRIPTION
This pull request introduces several improvements and fixes across the codebase, focusing on enhanced correctness, API ergonomics, and feature completeness. The most notable changes include adding `Hash` support for `Quantity`, improving the safety and clarity of the `clamp` method, clarifying unit symbol handling for composite units, refining FFI error handling, and updating documentation and tests accordingly.

### Core library improvements

* Implemented the `Hash` trait for `Quantity<U, S>` when the underlying scalar supports hashing, allowing `Quantity` to be used as keys in `HashMap` and `HashSet` (`qtty-core/src/quantity.rs`).
* Added a debug assertion to `Quantity::clamp` to ensure that `min_val <= max_val`, preventing incorrect usage and potential bugs (`qtty-core/src/quantity.rs`).
* Updated documentation and implementation for composite unit symbols (`Per`, `Prod`): clarified that `SYMBOL` is an empty string for these generics, and user-facing formatting should use `Display`/`LowerExp`/`UpperExp` (`qtty-core/src/unit.rs`). [[1]](diffhunk://#diff-68ed0e8043622932cea24513aab55cacd3c0a755c0b9db10b36cbf854268f5e9R19-R22) [[2]](diffhunk://#diff-68ed0e8043622932cea24513aab55cacd3c0a755c0b9db10b36cbf854268f5e9R69-R70) [[3]](diffhunk://#diff-68ed0e8043622932cea24513aab55cacd3c0a755c0b9db10b36cbf854268f5e9R122-R123)

### FFI (Foreign Function Interface) improvements

* Changed FFI conversion error types from `i32` to the more descriptive `QttyStatus` enum, improving type safety and clarity in error handling (`qtty-ffi/src/macros.rs`, `qtty-ffi/src/helpers.rs`). [[1]](diffhunk://#diff-a00124cad9ca1b4ff8974eecc2ff1896ca6296c418ddf12116dbb3333b6eb7a0L109-R114) [[2]](diffhunk://#diff-47a4aa0a1361346ab0ced5e67f0c181e6bdb851d3f1be749435ec003e0f10eabL50-R53) [[3]](diffhunk://#diff-47a4aa0a1361346ab0ced5e67f0c181e6bdb851d3f1be749435ec003e0f10eabL121-R122)

### Tests and documentation

* Added and updated tests to cover new behaviors: `Quantity` as `HashMap`/`HashSet` keys, `clamp` method assertions, and the FFI conversion error type. Also improved documentation for `from_dms_sign` and composite unit formatting (`qtty-core/tests/integers.rs`, `qtty-core/tests/core.rs`, `qtty-core/src/units/angular/mod.rs`). [[1]](diffhunk://#diff-c2c75b8132274e3d2eb1ae4b98de187384947f79e0f8bd66bdb82bac52b89dedR160-R173) [[2]](diffhunk://#diff-953609e35ff0ad3dc9fda802d6031d70f25217f22e48df1561e9f299ff57a226R154-R168) [[3]](diffhunk://#diff-49e4f029371831655f294b8c785cd81f5e0772c67486465fc8e57903c8413179L315-R316) [[4]](diffhunk://#diff-49e4f029371831655f294b8c785cd81f5e0772c67486465fc8e57903c8413179R788-R793)

### Build and compatibility

* Specified the minimum Rust version as `1.82` in `Cargo.toml` for improved build reproducibility and clarity.