### PR TITLE
Add typed unit aliases, constants, and integration tolerances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,54 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and
 
 ## [Unreleased]
 
+### Added
+
+- **`satellite` feature** (`qtty`) — spacecraft astrodynamics helpers are now
+  gated behind the opt-in `satellite` feature (disabled by default).
+  - `qtty::dynamics`: typed unit aliases (`KmPerSecond`, `KmPerSecondSquared`,
+    `InverseSecond`, `AreaToMassUnit`, `GravitationalParameterUnit`), typed
+    quantity aliases (`KmPerSeconds`, `KmPerSecondsSquared`, `InverseSeconds`,
+    `AreaToMass`, `GravitationalParameter`), gravitational parameter constants
+    (`GM_EARTH`, `GM_SUN`, `GM_MOON`, `SPEED_OF_LIGHT_KM_S`), and
+    dimensionless coefficient newtypes (`DragCoefficient`, `SrpCoefficient`,
+    `J2Coefficient`, `StokesCoefficient`).
+  - `qtty::tolerances`: typed ODE integrator tolerance newtypes
+    (`RelativeTolerance`, `AbsoluteTolerancePosition`,
+    `AbsoluteToleranceVelocity`, `IntegratorTolerances`) for propagator
+    configuration.
+
+- **Dimensionless transcendental helpers** on `Quantity<U, S>` where
+  `U: AngularUnit<Dim = Dimensionless>` (`qtty-core`):
+  - `exp(self) -> Quantity<Ratio, S>` — computes `e^self`.
+  - `ln(self)  -> Quantity<Ratio, S>` — computes the natural logarithm.
+  - `powi(self, n: i32) -> Quantity<Ratio, S>` — integer exponentiation.
+  - `powf(self, exp: Quantity<Ratio, S>) -> Quantity<Ratio, S>` — floating-point
+    exponentiation with a typed exponent.
+
+- **`ratio_to` helper** on `Quantity<U, S>` — divides two same-unit quantities
+  and returns the dimensionless `Quantity<Ratio, S>`, replacing the previous
+  pattern of converting to raw scalars before dividing.
+
+### Fixed
+
+- **Architecture boundary** (`qtty`) — `dynamics` and `tolerances` modules are
+  no longer publicly re-exported by default; enabling `satellite` is required.
+  This keeps `qtty` domain-agnostic for users who do not need astrodynamics
+  primitives.
+
+- **FFI consistency coverage** (`qtty-ffi`) — exhaustive inventory checks now
+  cover all exposed dimension families (previously only 7 of ~30 were checked).
+  Every `UnitId` discriminant range is verified against the corresponding Rust
+  unit's reported dimension.
+
+- **`to_lossy` documentation** (`qtty-core`) — the doc comment now includes an
+  explicit silent-saturation warning and a decision table guiding callers toward
+  `checked_to_lossy` when values may be out of range.
+
+- **Unused import warning under `--no-default-features`** (`qtty-core`) — the
+  `use core::cmp::Ordering` import in `audit_regressions.rs` is now correctly
+  gated on `#[cfg(feature = "cross-unit-ops")]`.
+
 ## [0.7.1] - 2026-05-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -19,15 +19,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -51,6 +51,12 @@ dependencies = [
  "once_cell_polyfill",
  "windows-sys",
 ]
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "approx"
@@ -108,15 +114,15 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "byteorder"
@@ -126,9 +132,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cbindgen"
@@ -146,7 +152,7 @@ dependencies = [
  "serde_json",
  "syn",
  "tempfile",
- "toml",
+ "toml 0.9.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -157,18 +163,18 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.5.53"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.53"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -178,15 +184,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.6"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "connection-string"
@@ -231,9 +237,9 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "2.3.5"
+version = "2.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e130c806dccc85428c564f2dc5a96e05b6615a27c9a28776bd7761a9af4bb552"
+checksum = "9940fb8467a0a06312218ed384185cb8536aa10d8ec017d0ce7fad2c1bd882d5"
 dependencies = [
  "diesel_derives",
  "downcast-rs",
@@ -241,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "diesel_derives"
-version = "2.3.6"
+version = "2.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c30b2969f923fa1f73744b92bb7df60b858df8832742d9a3aceb79236c0be1d2"
+checksum = "d1817b7f4279b947fc4cafddec12b0e5f8727141706561ce3ac94a60bddd1cf5"
 dependencies = [
  "diesel_table_macro_syntax",
  "dsl_auto_type",
@@ -334,9 +340,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fnv"
@@ -345,22 +351,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "futures-core"
-version = "0.3.31"
+name = "foldhash"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -369,21 +381,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-io",
@@ -392,7 +404,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -404,8 +415,21 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -416,15 +440,30 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ident_case"
@@ -434,12 +473,14 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
-version = "2.12.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -450,37 +491,45 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.178"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
@@ -490,9 +539,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "num-integer"
@@ -524,9 +573,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -536,21 +585,15 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "ppv-lite86"
@@ -568,19 +611,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6fa0831dd7cc608c38a5e323422a0077678fa5744aa2be4ad91c4ece8eec8d5"
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.103"
+name = "prettyplease"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "proptest"
-version = "1.9.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
@@ -597,9 +650,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf85e27e86080aafd5a22eae58a162e133a589551542b3e5cee4beb27e54f8e1"
+checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
 dependencies = [
  "libc",
  "once_cell",
@@ -611,18 +664,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf94ee265674bf76c09fa430b0e99c26e319c945d96ca0d5a8215f31bf81cf7"
+checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "491aa5fc66d8059dd44a75f4580a2962c1862a1c2945359db36f6c2818b748dc"
+checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -630,9 +683,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d671734e9d7a43449f8480f8b38115df67bef8d21f76837fa75ee7aaa5e52e"
+checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -642,9 +695,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22faaa1ce6c430a1f71658760497291065e6450d7b5dc2bcf254d49f66ee700a"
+checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -717,9 +770,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -731,10 +784,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "rand"
-version = "0.9.2"
+name = "r-efi"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -752,11 +811,11 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -770,15 +829,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rustix"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
@@ -806,10 +865,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ryu"
-version = "1.0.20"
+name = "semver"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -843,31 +902,31 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "strsim"
@@ -877,9 +936,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.111"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -888,9 +947,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1dd07eb858a2067e2f3c7155d54e929265c264e6f37efe3ee7a8d1b5a1dd0ba"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "target-triple"
@@ -900,12 +959,12 @@ checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
 
 [[package]]
 name = "tempfile"
-version = "3.23.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -965,17 +1024,32 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.11+spec-1.1.0"
+version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3afc9a848309fe1aaffaed6e1546a7a14de1f935dc9d89d32afd9a44bab7c46"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -988,19 +1062,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_parser"
-version = "1.0.6+spec-1.1.0"
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
- "winnow",
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.2",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tracing"
@@ -1036,9 +1119,9 @@ dependencies = [
 
 [[package]]
 name = "trybuild"
-version = "1.0.115"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f614c21bd3a61bad9501d75cbb7686f00386c806d7f456778432c25cf86948a"
+checksum = "47c635f0191bd3a2941013e5062667100969f8c4e9cd787c14f977265d73616e"
 dependencies = [
  "glob",
  "serde",
@@ -1046,14 +1129,14 @@ dependencies = [
  "serde_json",
  "target-triple",
  "termcolor",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
 ]
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unarray"
@@ -1063,9 +1146,15 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "utf8parse"
@@ -1075,9 +1164,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.19.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1094,18 +1183,27 @@ dependencies = [
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1116,9 +1214,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1126,9 +1224,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1139,11 +1237,45 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -1172,32 +1304,132 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+
+[[package]]
+name = "winnow"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.46.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.31"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.31"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/qtty-core/src/quantity.rs
+++ b/qtty-core/src/quantity.rs
@@ -1032,3 +1032,79 @@ where
         Quantity::new(self.0.atan())
     }
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Transcendental helpers on dimensionless quantities (Real suffices)
+// ─────────────────────────────────────────────────────────────────────────────
+
+impl<U, S> Quantity<U, S>
+where
+    U: Unit<Dim = crate::dimension::Dimensionless>,
+    S: Real,
+{
+    /// Returns e^self as a typed dimensionless [`Ratio`](crate::units::dimensionless::Ratio).
+    ///
+    /// Useful for density-scale-height models, population factors, and any
+    /// expression of the form `exp(-h / H)` where the argument is dimensionless.
+    #[inline]
+    pub fn exp(self) -> Quantity<crate::units::dimensionless::Ratio, S> {
+        Quantity::new(self.0.exp())
+    }
+
+    /// Returns the natural logarithm ln(self) as a typed dimensionless [`Ratio`].
+    ///
+    /// The result is dimensionless regardless of which dimensionless unit `U` is used.
+    #[inline]
+    pub fn ln(self) -> Quantity<crate::units::dimensionless::Ratio, S> {
+        Quantity::new(self.0.ln())
+    }
+
+    /// Returns self raised to the integer power `n` as a typed dimensionless [`Ratio`].
+    ///
+    /// Dimensionless^n is still dimensionless for any integer `n`.
+    #[inline]
+    pub fn powi(self, n: i32) -> Quantity<crate::units::dimensionless::Ratio, S> {
+        Quantity::new(self.0.powi(n))
+    }
+
+    /// Returns self raised to the dimensionless power `exp` as a typed dimensionless [`Ratio`].
+    ///
+    /// The exponent must itself be a dimensionless [`Ratio`] so the intent is explicit.
+    #[inline]
+    pub fn powf(
+        self,
+        exp: Quantity<crate::units::dimensionless::Ratio, S>,
+    ) -> Quantity<crate::units::dimensionless::Ratio, S> {
+        Quantity::new(self.0.powf(exp.0))
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ratio_to: same-dimension division returning a typed Ratio
+// ─────────────────────────────────────────────────────────────────────────────
+
+impl<U: Unit, S: Real> Quantity<U, S> {
+    /// Divides `self` by `other` (same unit), returning a typed dimensionless
+    /// [`Ratio`](crate::units::dimensionless::Ratio) instead of a raw scalar.
+    ///
+    /// This is an opt-in alternative to the standard `Quantity / Quantity`
+    /// operator, which returns the raw scalar `S` for same-unit division.
+    /// Use `ratio_to` whenever you want the result wrapped in a `Quantity`
+    /// for downstream typed APIs.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use qtty_core::length::Meters;
+    /// use qtty_core::units::dimensionless::Ratios;
+    ///
+    /// let a = Meters::new(10.0);
+    /// let b = Meters::new(4.0);
+    /// let r: Ratios = a.ratio_to(b);
+    /// assert!((r.value() - 2.5).abs() < 1e-12);
+    /// ```
+    #[inline]
+    pub fn ratio_to(self, other: Self) -> Quantity<crate::units::dimensionless::Ratio, S> {
+        Quantity::new(self.0 / other.0)
+    }
+}

--- a/qtty-core/src/quantity.rs
+++ b/qtty-core/src/quantity.rs
@@ -441,8 +441,17 @@ impl<U: Unit, S: Exact> Quantity<U, S> {
     /// - **Saturation at integer bounds** when the converted value exceeds the
     ///   target type's range (e.g. `1 km → 127 m` for `i8`).
     ///
-    /// Use [`checked_to_lossy`](Self::checked_to_lossy) if you need to detect
-    /// range overflow.
+    /// # When to use which variant
+    ///
+    /// | Situation | Recommended API |
+    /// |-----------|-----------------|
+    /// | Overflow is impossible by domain invariant | `to_lossy` |
+    /// | Overflow is possible / value is untrusted | [`checked_to_lossy`](Self::checked_to_lossy) |
+    ///
+    /// Prefer [`checked_to_lossy`](Self::checked_to_lossy) whenever the input
+    /// value comes from external data or a computation that might produce a
+    /// value outside the target type's range.  Silent saturation is an easy
+    /// source of subtle bugs in integer-heavy code.
     ///
     /// # Example
     ///

--- a/qtty-core/tests/audit_regressions.rs
+++ b/qtty-core/tests/audit_regressions.rs
@@ -7,6 +7,7 @@
 //! - QTTY-002: Integer `abs()` at signed minimum
 //! - QTTY-003: `to_lossy()` / `checked_to_lossy()` overflow detection
 
+#[cfg(feature = "cross-unit-ops")]
 use core::cmp::Ordering;
 use qtty_core::length::{Kilometer, Meter};
 use qtty_core::Quantity;

--- a/qtty-core/tests/core.rs
+++ b/qtty-core/tests/core.rs
@@ -760,7 +760,7 @@ fn cross_unit_nan_comparison() {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// TODO-1 tests: Ratio arithmetic, exp/ln roundtrip, powi/powf, ratio_to
+// tests: Ratio arithmetic, exp/ln roundtrip, powi/powf, ratio_to
 // ─────────────────────────────────────────────────────────────────────────────
 
 #[test]

--- a/qtty-core/tests/core.rs
+++ b/qtty-core/tests/core.rs
@@ -758,3 +758,68 @@ fn cross_unit_nan_comparison() {
     assert!(!(km_nan == m));
     assert!(km_nan.partial_cmp(&m).is_none());
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TODO-1 tests: Ratio arithmetic, exp/ln roundtrip, powi/powf, ratio_to
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn ratio_basic_arithmetic() {
+    use qtty_core::units::dimensionless::Ratios;
+
+    let a = Ratios::new(3.0);
+    let b = Ratios::new(2.0);
+
+    assert_eq!((a + b).value(), 5.0);
+    assert_eq!((a - b).value(), 1.0);
+    // scalar multiplication
+    assert_eq!((a * 2.0).value(), 6.0);
+    // same-unit division returns raw scalar
+    let raw: f64 = a / b;
+    assert!((raw - 1.5).abs() < 1e-12);
+}
+
+#[test]
+#[cfg(feature = "std")]
+fn ratio_exp_ln_roundtrip() {
+    use qtty_core::units::dimensionless::Ratios;
+
+    let x = Ratios::new(1.5);
+    let roundtrip = x.exp().ln();
+    assert!((roundtrip.value() - 1.5).abs() < 1e-12);
+}
+
+#[test]
+#[cfg(feature = "std")]
+fn ratio_powi() {
+    use qtty_core::units::dimensionless::Ratios;
+
+    let x = Ratios::new(2.0);
+    let result = x.powi(3);
+    assert!((result.value() - 8.0).abs() < 1e-12);
+}
+
+#[test]
+#[cfg(feature = "std")]
+fn ratio_powf() {
+    use qtty_core::units::dimensionless::{Ratio, Ratios};
+    use qtty_core::Quantity;
+
+    let base = Ratios::new(4.0);
+    let exp = Quantity::<Ratio>::new(0.5);
+    let result = base.powf(exp);
+    // 4^0.5 == 2
+    assert!((result.value() - 2.0).abs() < 1e-12);
+}
+
+#[test]
+#[cfg(feature = "std")]
+fn ratio_to_same_unit_division() {
+    use qtty_core::units::dimensionless::Ratios;
+    use qtty_core::units::length::Meters;
+
+    let a = Meters::new(10.0);
+    let b = Meters::new(4.0);
+    let r: Ratios = a.ratio_to(b);
+    assert!((r.value() - 2.5).abs() < 1e-12);
+}

--- a/qtty-ffi/tests/consistency.rs
+++ b/qtty-ffi/tests/consistency.rs
@@ -21,7 +21,11 @@
 //!    entries fail compilation during the crate build, so this file does not
 //!    need to duplicate that check.
 //!
-//! Dimensions currently covered: Angle, Length, Mass, Power, Time, Area, Volume.
+//! Dimensions covered: all exposed families (Angle, Length, Mass, Power, Time,
+//! Area, Volume, Acceleration, Force, Energy, Pressure, SolidAngle, Temperature,
+//! Radiometry, Photometry, Frequency, AmountOfSubstance, Electrical, Density,
+//! Dimensionless) plus all feature-gated sub-families (astro, customary,
+//! navigation, fundamental-physics, land-area).
 
 use qtty::Unit;
 use qtty_ffi::{registry, UnitId};
@@ -40,7 +44,8 @@ macro_rules! assert_unit_has_ffi_id {
     };
 }
 
-// Dimensions whose inventory names match their FFI variant names 1:1.
+// ── Always-available base dimensions ─────────────────────────────────────────
+
 qtty_core::angular_units!(assert_unit_has_ffi_id);
 qtty_core::length_units!(assert_unit_has_ffi_id);
 qtty_core::time_units!(assert_unit_has_ffi_id);
@@ -48,6 +53,71 @@ qtty_core::mass_units!(assert_unit_has_ffi_id);
 qtty_core::power_units!(assert_unit_has_ffi_id);
 qtty_core::area_units!(assert_unit_has_ffi_id);
 qtty_core::volume_units!(assert_unit_has_ffi_id);
+qtty_core::acceleration_units!(assert_unit_has_ffi_id);
+qtty_core::force_units!(assert_unit_has_ffi_id);
+qtty_core::energy_units!(assert_unit_has_ffi_id);
+qtty_core::pressure_units!(assert_unit_has_ffi_id);
+qtty_core::solid_angle_units!(assert_unit_has_ffi_id);
+qtty_core::temperature_units!(assert_unit_has_ffi_id);
+
+// ── Feature-gated sub-families (all enabled via qtty's "all-units" feature) ──
+
+// Astro extensions
+qtty_core::angular_astro_units!(assert_unit_has_ffi_id);
+qtty_core::length_astro_units!(assert_unit_has_ffi_id);
+qtty_core::mass_astro_units!(assert_unit_has_ffi_id);
+qtty_core::power_astro_units!(assert_unit_has_ffi_id);
+qtty_core::solid_angle_astro_units!(assert_unit_has_ffi_id);
+qtty_core::time_astro_units!(assert_unit_has_ffi_id);
+
+// Julian-time extensions
+qtty_core::time_julian_time_units!(assert_unit_has_ffi_id);
+
+// Navigation extensions
+qtty_core::angular_navigation_units!(assert_unit_has_ffi_id);
+qtty_core::length_navigation_units!(assert_unit_has_ffi_id);
+
+// Fundamental-physics extensions
+qtty_core::length_fundamental_physics_units!(assert_unit_has_ffi_id);
+qtty_core::mass_fundamental_physics_units!(assert_unit_has_ffi_id);
+qtty_core::power_fundamental_physics_units!(assert_unit_has_ffi_id);
+qtty_core::energy_fundamental_physics_units!(assert_unit_has_ffi_id);
+qtty_core::force_fundamental_physics_units!(assert_unit_has_ffi_id);
+
+// Customary extensions
+qtty_core::length_customary_units!(assert_unit_has_ffi_id);
+qtty_core::mass_customary_units!(assert_unit_has_ffi_id);
+qtty_core::power_customary_units!(assert_unit_has_ffi_id);
+qtty_core::area_customary_units!(assert_unit_has_ffi_id);
+qtty_core::volume_customary_units!(assert_unit_has_ffi_id);
+qtty_core::energy_customary_units!(assert_unit_has_ffi_id);
+qtty_core::pressure_customary_units!(assert_unit_has_ffi_id);
+qtty_core::force_customary_units!(assert_unit_has_ffi_id);
+qtty_core::density_customary_units!(assert_unit_has_ffi_id);
+
+// Land-area extensions
+qtty_core::area_land_area_units!(assert_unit_has_ffi_id);
+
+// Feature-gated dimension families
+qtty_core::radiance_units!(assert_unit_has_ffi_id);
+qtty_core::spectral_radiance_units!(assert_unit_has_ffi_id);
+qtty_core::photon_radiance_units!(assert_unit_has_ffi_id);
+qtty_core::spectral_photon_radiance_units!(assert_unit_has_ffi_id);
+qtty_core::inverse_solid_angle_units!(assert_unit_has_ffi_id);
+qtty_core::candela_units!(assert_unit_has_ffi_id);
+qtty_core::lumen_units!(assert_unit_has_ffi_id);
+qtty_core::lux_units!(assert_unit_has_ffi_id);
+qtty_core::frequency_units!(assert_unit_has_ffi_id);
+qtty_core::amount_units!(assert_unit_has_ffi_id);
+qtty_core::ampere_units!(assert_unit_has_ffi_id);
+qtty_core::coulomb_units!(assert_unit_has_ffi_id);
+qtty_core::volt_units!(assert_unit_has_ffi_id);
+qtty_core::ohm_units!(assert_unit_has_ffi_id);
+qtty_core::farad_units!(assert_unit_has_ffi_id);
+qtty_core::henry_units!(assert_unit_has_ffi_id);
+qtty_core::weber_units!(assert_unit_has_ffi_id);
+qtty_core::tesla_units!(assert_unit_has_ffi_id);
+qtty_core::density_units!(assert_unit_has_ffi_id);
 
 // Nominal length units use a `Nominal` prefix in the FFI enum.
 const _: UnitId = UnitId::NominalSolarRadius;
@@ -58,6 +128,16 @@ const _: UnitId = UnitId::NominalEarthPolarRadius;
 const _: UnitId = UnitId::NominalJupiterRadius;
 const _: UnitId = UnitId::NominalLunarRadius;
 const _: UnitId = UnitId::NominalLunarDistance;
+
+// Dimensionless units: `Ratio` is not exposed in the FFI; check the rest explicitly.
+assert_unit_has_ffi_id!(
+    OpticalDepth,
+    Airmass,
+    Transmittance,
+    Albedo,
+    IlluminationFraction,
+    Refractivity,
+);
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Smoke-test: trait-derived metadata matches qtty-core (runtime)
@@ -99,6 +179,7 @@ macro_rules! check_trait_metadata {
 
 #[test]
 fn trait_metadata_consistent_with_registry() {
+    // Always-available base dimensions
     qtty_core::angular_units!(check_trait_metadata);
     qtty_core::length_units!(check_trait_metadata);
     qtty_core::time_units!(check_trait_metadata);
@@ -106,4 +187,67 @@ fn trait_metadata_consistent_with_registry() {
     qtty_core::power_units!(check_trait_metadata);
     qtty_core::area_units!(check_trait_metadata);
     qtty_core::volume_units!(check_trait_metadata);
+    qtty_core::acceleration_units!(check_trait_metadata);
+    qtty_core::force_units!(check_trait_metadata);
+    qtty_core::energy_units!(check_trait_metadata);
+    qtty_core::pressure_units!(check_trait_metadata);
+    qtty_core::solid_angle_units!(check_trait_metadata);
+    qtty_core::temperature_units!(check_trait_metadata);
+
+    // Feature-gated sub-families (all enabled via all-units)
+    qtty_core::angular_astro_units!(check_trait_metadata);
+    qtty_core::length_astro_units!(check_trait_metadata);
+    qtty_core::mass_astro_units!(check_trait_metadata);
+    qtty_core::power_astro_units!(check_trait_metadata);
+    qtty_core::solid_angle_astro_units!(check_trait_metadata);
+    qtty_core::time_astro_units!(check_trait_metadata);
+    qtty_core::time_julian_time_units!(check_trait_metadata);
+    qtty_core::angular_navigation_units!(check_trait_metadata);
+    qtty_core::length_navigation_units!(check_trait_metadata);
+    qtty_core::length_fundamental_physics_units!(check_trait_metadata);
+    qtty_core::mass_fundamental_physics_units!(check_trait_metadata);
+    qtty_core::power_fundamental_physics_units!(check_trait_metadata);
+    qtty_core::energy_fundamental_physics_units!(check_trait_metadata);
+    qtty_core::force_fundamental_physics_units!(check_trait_metadata);
+    qtty_core::length_customary_units!(check_trait_metadata);
+    qtty_core::mass_customary_units!(check_trait_metadata);
+    qtty_core::power_customary_units!(check_trait_metadata);
+    qtty_core::area_customary_units!(check_trait_metadata);
+    qtty_core::volume_customary_units!(check_trait_metadata);
+    qtty_core::energy_customary_units!(check_trait_metadata);
+    qtty_core::pressure_customary_units!(check_trait_metadata);
+    qtty_core::force_customary_units!(check_trait_metadata);
+    qtty_core::density_customary_units!(check_trait_metadata);
+    qtty_core::area_land_area_units!(check_trait_metadata);
+
+    // Feature-gated dimension families
+    qtty_core::radiance_units!(check_trait_metadata);
+    qtty_core::spectral_radiance_units!(check_trait_metadata);
+    qtty_core::photon_radiance_units!(check_trait_metadata);
+    qtty_core::spectral_photon_radiance_units!(check_trait_metadata);
+    qtty_core::inverse_solid_angle_units!(check_trait_metadata);
+    qtty_core::candela_units!(check_trait_metadata);
+    qtty_core::lumen_units!(check_trait_metadata);
+    qtty_core::lux_units!(check_trait_metadata);
+    qtty_core::frequency_units!(check_trait_metadata);
+    qtty_core::amount_units!(check_trait_metadata);
+    qtty_core::ampere_units!(check_trait_metadata);
+    qtty_core::coulomb_units!(check_trait_metadata);
+    qtty_core::volt_units!(check_trait_metadata);
+    qtty_core::ohm_units!(check_trait_metadata);
+    qtty_core::farad_units!(check_trait_metadata);
+    qtty_core::henry_units!(check_trait_metadata);
+    qtty_core::weber_units!(check_trait_metadata);
+    qtty_core::tesla_units!(check_trait_metadata);
+    qtty_core::density_units!(check_trait_metadata);
+
+    // Dimensionless (Ratio excluded — not exposed in FFI)
+    check_trait_metadata!(
+        OpticalDepth,
+        Airmass,
+        Transmittance,
+        Albedo,
+        IlluminationFraction,
+        Refractivity,
+    );
 }

--- a/qtty/Cargo.toml
+++ b/qtty/Cargo.toml
@@ -33,6 +33,9 @@ electrical = ["qtty-core/electrical"]
 density = ["qtty-core/density"]
 all-units = ["astro", "navigation", "fundamental-physics", "customary", "land-area", "radiometry", "photometry", "frequency", "chemistry", "electrical", "density"]
 
+# Domain-specific extensions (disabled by default to keep qtty domain-agnostic)
+satellite = []
+
 # Scalar type support
 scalar-rational = ["qtty-core/scalar-rational"]
 pyo3 = ["qtty-core/pyo3", "dep:pyo3"]

--- a/qtty/src/dynamics.rs
+++ b/qtty/src/dynamics.rs
@@ -110,6 +110,11 @@ pub const GM_SUN: GravitationalParameter = GravitationalParameter::new(1.327_124
 /// μ_☾ = 4.902 800 066 × 10³ km³/s²
 pub const GM_MOON: GravitationalParameter = GravitationalParameter::new(4.902_800_066e3);
 
+/// Speed of light in vacuum (km/s).
+///
+/// c = 299 792.458 km/s (exact by SI definition).
+pub const SPEED_OF_LIGHT_KM_S: KmPerSeconds = KmPerSeconds::new(299_792.458);
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Semantic dimensionless coefficient newtypes
 // ─────────────────────────────────────────────────────────────────────────────

--- a/qtty/src/dynamics.rs
+++ b/qtty/src/dynamics.rs
@@ -1,0 +1,272 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (C) 2026 Vallés Puig, Ramon
+
+//! Typed unit aliases and physical constants for spacecraft astrodynamics.
+//!
+//! This module provides the unit aliases and semantic coefficient newtypes that the
+//! `siderust::astro::dynamics` redesign requires.  They live in `qtty` rather than
+//! `siderust` because they are pure quantity/unit definitions with no observational
+//! or ephemeris semantics.
+//!
+//! ## Unit aliases
+//!
+//! | Alias | Expansion | Typical use |
+//! |-------|-----------|-------------|
+//! | [`KmPerSecond`] | `Per<Kilometer, Second>` | Orbital velocity |
+//! | [`KmPerSecondSquared`] | `Per<Per<Kilometer, Second>, Second>` | Acceleration in km/s² |
+//! | [`InverseSecond`] | `Per<Ratio, Second>` | Decay/rate, inverse-time quantities |
+//! | [`AreaToMassUnit`] | `Per<SquareMeter, Kilogram>` | Ballistic coefficient area/mass |
+//! | [`GravitationalParameter`] | `Quantity<Per<CubicKilometer, Prod<Second, Second>>>` | μ = G·M |
+//!
+//! ## Gravitational parameter constants
+//!
+//! | Constant | Value (km³/s²) | Reference |
+//! |----------|----------------|-----------|
+//! | [`GM_EARTH`] | 398 600.441 8 | EGM2008 / WGS-84 |
+//! | [`GM_SUN`] | 1.327 124 400 18 × 10¹¹ | IAU 2012 |
+//! | [`GM_MOON`] | 4.902 800 066 × 10³ | DE430 |
+//!
+//! ## Semantic coefficient newtypes
+//!
+//! [`DragCoefficient`], [`SrpCoefficient`], [`J2Coefficient`], and
+//! [`StokesCoefficient`] are thin wrappers around a bare `f64` that prevent
+//! accidental mixing of aerodynamic, solar-radiation-pressure, gravitational
+//! zonal, and tesseral/sectorial harmonic coefficients in force-model APIs.
+
+use qtty_core::units::area::SquareMeter;
+use qtty_core::units::dimensionless::Ratio;
+use qtty_core::units::length::Kilometer;
+use qtty_core::units::mass::Kilogram;
+use qtty_core::units::time::Second;
+use qtty_core::units::volume::CubicKilometer;
+use qtty_core::{Per, Prod, Quantity};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Unit type aliases
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Unit marker for kilometre per second (km/s).
+///
+/// Canonical orbital-velocity unit used throughout astrodynamics.
+pub type KmPerSecond = Per<Kilometer, Second>;
+
+/// Quantity alias: a velocity in km/s.
+pub type KmPerSeconds = Quantity<KmPerSecond>;
+
+/// Unit marker for kilometre per second squared (km/s²).
+///
+/// Astrodynamics acceleration unit: `(km/s) / s`.
+pub type KmPerSecondSquared = Per<Per<Kilometer, Second>, Second>;
+
+/// Quantity alias: an acceleration in km/s².
+pub type KmPerSecondsSquared = Quantity<KmPerSecondSquared>;
+
+/// Unit marker for inverse-second (1/s).
+///
+/// Represents a rate or decay constant.  The numerator uses [`Ratio`] as the
+/// dimensionless "one" unit, giving the dimension `Dimensionless / Time`.
+pub type InverseSecond = Per<Ratio, Second>;
+
+/// Quantity alias: a rate or decay constant in 1/s.
+pub type InverseSeconds = Quantity<InverseSecond>;
+
+/// Unit marker for area-to-mass ratio (m²/kg).
+///
+/// Used as the effective cross-sectional area per unit mass in drag and SRP
+/// force models.
+pub type AreaToMassUnit = Per<SquareMeter, Kilogram>;
+
+/// Quantity alias: an area-to-mass ratio in m²/kg.
+pub type AreaToMass = Quantity<AreaToMassUnit>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Gravitational parameter
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Unit marker for the standard gravitational parameter μ = G·M (km³/s²).
+///
+/// EGM2008 uses this convention: `μ_Earth ≈ 398 600.441 8 km³/s²`.
+/// The unit is `CubicKilometer / (Second * Second)`.
+pub type GravitationalParameterUnit = Per<CubicKilometer, Prod<Second, Second>>;
+
+/// Typed standard gravitational parameter: km³/s².
+///
+/// Used for G·M of Earth, Sun, Moon, and any other body expressed in the
+/// conventional astrodynamics unit.
+pub type GravitationalParameter = Quantity<GravitationalParameterUnit>;
+
+/// Earth standard gravitational parameter (EGM2008 / WGS-84).
+///
+/// μ_⊕ = 398 600.441 8 km³/s²
+pub const GM_EARTH: GravitationalParameter = GravitationalParameter::new(398_600.441_8);
+
+/// Sun standard gravitational parameter (IAU 2012 system).
+///
+/// μ_☉ = 1.327 124 400 18 × 10¹¹ km³/s²
+pub const GM_SUN: GravitationalParameter = GravitationalParameter::new(1.327_124_400_18e11);
+
+/// Moon standard gravitational parameter (DE430 value).
+///
+/// μ_☾ = 4.902 800 066 × 10³ km³/s²
+pub const GM_MOON: GravitationalParameter = GravitationalParameter::new(4.902_800_066e3);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Semantic dimensionless coefficient newtypes
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Aerodynamic drag coefficient C_D (dimensionless).
+///
+/// Physically represents the ratio of drag force to the product of dynamic
+/// pressure and reference area. Typical values: 2.0–2.4 for flat plates in
+/// free-molecular flow.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct DragCoefficient(f64);
+
+impl DragCoefficient {
+    /// Creates a new drag coefficient from a raw dimensionless value.
+    #[inline]
+    pub fn new(value: f64) -> Self {
+        Self(value)
+    }
+
+    /// Returns the raw dimensionless value.
+    #[inline]
+    pub fn value(self) -> f64 {
+        self.0
+    }
+}
+
+/// Solar radiation pressure coefficient C_R (dimensionless).
+///
+/// Scales the ideal-reflector SRP force.  A perfectly absorbing surface has
+/// C_R = 1.0; a perfect specular mirror has C_R = 2.0.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct SrpCoefficient(f64);
+
+impl SrpCoefficient {
+    /// Creates a new SRP coefficient from a raw dimensionless value.
+    #[inline]
+    pub fn new(value: f64) -> Self {
+        Self(value)
+    }
+
+    /// Returns the raw dimensionless value.
+    #[inline]
+    pub fn value(self) -> f64 {
+        self.0
+    }
+}
+
+/// Gravitational zonal harmonic J₂ coefficient (dimensionless).
+///
+/// The dominant oblateness term in the geopotential expansion.
+/// For Earth: J₂ ≈ 1.082 635 9 × 10⁻³ (EGM2008).
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct J2Coefficient(f64);
+
+impl J2Coefficient {
+    /// Creates a new J₂ coefficient from a raw dimensionless value.
+    #[inline]
+    pub fn new(value: f64) -> Self {
+        Self(value)
+    }
+
+    /// Returns the raw dimensionless value.
+    #[inline]
+    pub fn value(self) -> f64 {
+        self.0
+    }
+}
+
+/// Stokes (spherical-harmonic) geopotential coefficient C_nm or S_nm (dimensionless).
+///
+/// Stores a single fully-normalised Stokes coefficient as used in the EGM2008
+/// and similar gravity-field models.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct StokesCoefficient(f64);
+
+impl StokesCoefficient {
+    /// Creates a new Stokes coefficient from a raw dimensionless value.
+    #[inline]
+    pub fn new(value: f64) -> Self {
+        Self(value)
+    }
+
+    /// Returns the raw dimensionless value.
+    #[inline]
+    pub fn value(self) -> f64 {
+        self.0
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+    use qtty_core::units::length::Kilometers;
+    use qtty_core::units::time::Seconds;
+
+    // ── Gravitational parameter constants ─────────────────────────────────────
+
+    #[test]
+    fn gm_earth_value() {
+        assert!((GM_EARTH.value() - 398_600.441_8).abs() < 1e-3);
+    }
+
+    #[test]
+    fn gm_sun_order_of_magnitude() {
+        assert!(GM_SUN.value() > 1e11 && GM_SUN.value() < 1.4e11);
+    }
+
+    #[test]
+    fn gm_moon_order_of_magnitude() {
+        assert!(GM_MOON.value() > 4_000.0 && GM_MOON.value() < 6_000.0);
+    }
+
+    // ── Coefficient newtypes ──────────────────────────────────────────────────
+
+    #[test]
+    fn drag_coefficient_roundtrip() {
+        let cd = DragCoefficient::new(2.2);
+        assert!((cd.value() - 2.2).abs() < 1e-15);
+    }
+
+    #[test]
+    fn srp_coefficient_roundtrip() {
+        let cr = SrpCoefficient::new(1.5);
+        assert!((cr.value() - 1.5).abs() < 1e-15);
+    }
+
+    #[test]
+    fn j2_coefficient_roundtrip() {
+        let j2 = J2Coefficient::new(1.082_635_9e-3);
+        assert!((j2.value() - 1.082_635_9e-3).abs() < 1e-20);
+    }
+
+    #[test]
+    fn stokes_coefficient_roundtrip() {
+        let c = StokesCoefficient::new(-0.484_165_4e-3);
+        assert!((c.value() - (-0.484_165_4e-3)).abs() < 1e-20);
+    }
+
+    // ── Dimensional alias correctness ─────────────────────────────────────────
+
+    /// KmPerSecondSquared * Second * Second should produce Kilometers.
+    ///
+    /// `(km/s)/s * s = km/s`, then `km/s * s = km`.
+    #[test]
+    fn km_per_second_squared_dimensional() {
+        // 2 km/s² * 3 s = 6 km/s
+        let a: Quantity<KmPerSecondSquared> = Quantity::new(2.0);
+        let t = Seconds::new(3.0);
+        // (km/s)/s * s → km/s  (Per<N,D> * D → N)
+        let v: KmPerSeconds = a * t;
+        assert!((v.value() - 6.0).abs() < 1e-12);
+        // km/s * s → km
+        let d: Kilometers = v * Seconds::new(1.0);
+        assert!((d.value() - 6.0).abs() < 1e-12);
+    }
+}

--- a/qtty/src/lib.rs
+++ b/qtty/src/lib.rs
@@ -107,6 +107,9 @@
 //! - `alloc`: enables heap-backed helpers (like `qtty_vec!(vec ...)`) in `no_std` builds.
 //! - `serde`: enables `serde` support for `Quantity<U, S>`; serialization is the raw scalar value.
 //! - `scalar-rational`: enables `num_rational::Rational64` as a scalar type.
+//! - `satellite`: enables spacecraft astrodynamics unit aliases, gravitational parameter constants,
+//!   dimensionless force-model coefficient newtypes (`DragCoefficient`, `SrpCoefficient`, …), and
+//!   ODE propagator tolerance newtypes.  Disabled by default to keep `qtty` domain-agnostic.
 //!
 //! # Custom Units
 //!
@@ -188,6 +191,7 @@ pub use qtty_core::{
     Transcendental, Unit, Velocity, Voltage, Volume,
 };
 
+#[cfg(feature = "satellite")]
 pub use dynamics::{
     AreaToMass, AreaToMassUnit, DragCoefficient, GravitationalParameter,
     GravitationalParameterUnit, InverseSecond, InverseSeconds, J2Coefficient, KmPerSecond,
@@ -195,6 +199,7 @@ pub use dynamics::{
     GM_EARTH, GM_MOON, GM_SUN,
 };
 
+#[cfg(feature = "satellite")]
 pub use tolerances::{
     AbsoluteTolerancePosition, AbsoluteToleranceVelocity, IntegratorTolerances, RelativeTolerance,
 };
@@ -391,7 +396,9 @@ macro_rules! __qtty_invoke_optional_inventories {
 // Scalar-specific modules
 // ─────────────────────────────────────────────────────────────────────────────
 
+#[cfg(feature = "satellite")]
 pub mod dynamics;
+#[cfg(feature = "satellite")]
 pub mod tolerances;
 
 pub mod f32;

--- a/qtty/src/lib.rs
+++ b/qtty/src/lib.rs
@@ -188,6 +188,17 @@ pub use qtty_core::{
     Transcendental, Unit, Velocity, Voltage, Volume,
 };
 
+pub use dynamics::{
+    AreaToMass, AreaToMassUnit, DragCoefficient, GravitationalParameter,
+    GravitationalParameterUnit, InverseSecond, InverseSeconds, J2Coefficient, KmPerSecond,
+    KmPerSecondSquared, KmPerSeconds, KmPerSecondsSquared, SrpCoefficient, StokesCoefficient,
+    GM_EARTH, GM_MOON, GM_SUN,
+};
+
+pub use tolerances::{
+    AbsoluteTolerancePosition, AbsoluteToleranceVelocity, IntegratorTolerances, RelativeTolerance,
+};
+
 // `UnitDiv`, `UnitMul`, and the dimension-level traits are needed by the
 // `impl_unit_*` macros when they expand in downstream crates.  They are
 // also useful for writing generic code, but their associated types expose
@@ -379,6 +390,9 @@ macro_rules! __qtty_invoke_optional_inventories {
 // ─────────────────────────────────────────────────────────────────────────────
 // Scalar-specific modules
 // ─────────────────────────────────────────────────────────────────────────────
+
+pub mod dynamics;
+pub mod tolerances;
 
 pub mod f32;
 pub mod f64;
@@ -607,6 +621,8 @@ pub use unit as units;
 pub mod velocity {
     #[cfg(feature = "astro")]
     pub use qtty_core::units::velocity::AU_PER_DAY_C;
+    #[cfg(feature = "astro")]
+    pub use qtty_core::units::velocity::C;
     pub use qtty_core::units::velocity::{Velocity, VelocityUnit};
 }
 

--- a/qtty/src/tolerances.rs
+++ b/qtty/src/tolerances.rs
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (C) 2026 Vallés Puig, Ramon
+
+//! Typed integration tolerances for ODE propagators.
+//!
+//! These newtypes wrap [`Quantity`] values to give clear names to the rel/abs
+//! tolerances that integrators like Dormand–Prince 5(4) and DOP853 require.
+//! They replace raw `f64` fields and prevent mixing relative and absolute
+//! tolerances accidentally.
+//!
+//! ## Usage
+//!
+//! ```rust
+//! use qtty::tolerances::IntegratorTolerances;
+//!
+//! let tol = IntegratorTolerances::uniform(1e-9, 1e-6, 1e-9);
+//! assert!((tol.rel.value() - 1e-9).abs() < 1e-20);
+//! ```
+
+use crate::dynamics::{KmPerSecond, KmPerSeconds};
+use qtty_core::units::dimensionless::{Ratio, Ratios};
+use qtty_core::units::length::{Kilometer, Kilometers};
+use qtty_core::Quantity;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// RelativeTolerance
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Typed relative tolerance for ODE integration (dimensionless).
+///
+/// Wraps a [`Ratios`] value. Typical values are `1e-9` to `1e-12` for
+/// high-precision orbit propagation.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct RelativeTolerance(pub Ratios);
+
+impl RelativeTolerance {
+    /// Creates a relative tolerance from a raw `f64` dimensionless value.
+    #[inline]
+    pub fn new(value: f64) -> Self {
+        Self(Quantity::<Ratio>::new(value))
+    }
+
+    /// Returns the raw dimensionless value.
+    #[inline]
+    pub fn value(self) -> f64 {
+        self.0.value()
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AbsoluteTolerancePosition
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Typed absolute position tolerance, parameterised by length unit.
+///
+/// Defaults to [`Kilometer`].  Typical values are `1e-3` km (1 metre) for
+/// near-Earth orbit propagation.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct AbsoluteTolerancePosition<U = Kilometer>(pub Quantity<U>)
+where
+    U: qtty_core::Unit<Dim = qtty_core::Length>;
+
+impl AbsoluteTolerancePosition<Kilometer> {
+    /// Creates a position tolerance in kilometres.
+    #[inline]
+    pub fn new_km(value: f64) -> Self {
+        Self(Kilometers::new(value))
+    }
+}
+
+impl<U> AbsoluteTolerancePosition<U>
+where
+    U: qtty_core::Unit<Dim = qtty_core::Length>,
+{
+    /// Creates a position tolerance from a typed length quantity.
+    #[inline]
+    pub fn new(quantity: Quantity<U>) -> Self {
+        Self(quantity)
+    }
+
+    /// Returns the raw numeric value in the stored unit.
+    #[inline]
+    pub fn value(self) -> f64
+    where
+        U: qtty_core::Unit<Dim = qtty_core::Length>,
+    {
+        self.0.value()
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AbsoluteToleranceVelocity
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Typed absolute velocity tolerance, parameterised by velocity unit.
+///
+/// Defaults to [`KmPerSecond`].  Typical values are `1e-6` km/s for
+/// near-Earth orbit propagation.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct AbsoluteToleranceVelocity<V = KmPerSecond>(pub Quantity<V>)
+where
+    V: qtty_core::Unit<Dim = qtty_core::Velocity>;
+
+impl AbsoluteToleranceVelocity<KmPerSecond> {
+    /// Creates a velocity tolerance in km/s.
+    #[inline]
+    pub fn new_km_s(value: f64) -> Self {
+        Self(KmPerSeconds::new(value))
+    }
+}
+
+impl<V> AbsoluteToleranceVelocity<V>
+where
+    V: qtty_core::Unit<Dim = qtty_core::Velocity>,
+{
+    /// Creates a velocity tolerance from a typed velocity quantity.
+    #[inline]
+    pub fn new(quantity: Quantity<V>) -> Self {
+        Self(quantity)
+    }
+
+    /// Returns the raw numeric value in the stored unit.
+    #[inline]
+    pub fn value(self) -> f64 {
+        self.0.value()
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// IntegratorTolerances
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Combined typed tolerances for a variable-step ODE integrator.
+///
+/// Holds:
+/// - `rel` — a single relative tolerance applied to all state components.
+/// - `abs_pos` — three per-axis absolute position tolerances (x, y, z).
+/// - `abs_vel` — three per-axis absolute velocity tolerances (vx, vy, vz).
+///
+/// Use [`IntegratorTolerances::uniform`] when you want the same threshold
+/// for all axes.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct IntegratorTolerances {
+    /// Relative tolerance (dimensionless).
+    pub rel: RelativeTolerance,
+    /// Per-axis absolute position tolerances (km by default).
+    pub abs_pos: [AbsoluteTolerancePosition; 3],
+    /// Per-axis absolute velocity tolerances (km/s by default).
+    pub abs_vel: [AbsoluteToleranceVelocity; 3],
+}
+
+impl IntegratorTolerances {
+    /// Constructs a set of tolerances with the same threshold for all axes.
+    ///
+    /// # Arguments
+    ///
+    /// * `rel` — dimensionless relative tolerance (e.g. `1e-9`).
+    /// * `abs_pos_km` — absolute position tolerance in kilometres (e.g. `1e-6` = 1 mm).
+    /// * `abs_vel_km_s` — absolute velocity tolerance in km/s (e.g. `1e-9`).
+    pub fn uniform(rel: f64, abs_pos_km: f64, abs_vel_km_s: f64) -> Self {
+        let abs_p = AbsoluteTolerancePosition::new_km(abs_pos_km);
+        let abs_v = AbsoluteToleranceVelocity::new_km_s(abs_vel_km_s);
+        Self {
+            rel: RelativeTolerance::new(rel),
+            abs_pos: [abs_p, abs_p, abs_p],
+            abs_vel: [abs_v, abs_v, abs_v],
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn relative_tolerance_roundtrip() {
+        let r = RelativeTolerance::new(1e-9);
+        assert!((r.value() - 1e-9).abs() < 1e-25);
+    }
+
+    #[test]
+    fn abs_pos_tolerance_roundtrip() {
+        let p = AbsoluteTolerancePosition::new_km(1e-6);
+        assert!((p.value() - 1e-6).abs() < 1e-22);
+    }
+
+    #[test]
+    fn abs_vel_tolerance_roundtrip() {
+        let v = AbsoluteToleranceVelocity::new_km_s(1e-9);
+        assert!((v.value() - 1e-9).abs() < 1e-25);
+    }
+
+    #[test]
+    fn integrator_tolerances_uniform() {
+        let tol = IntegratorTolerances::uniform(1e-9, 1e-6, 1e-9);
+        assert!((tol.rel.value() - 1e-9).abs() < 1e-25);
+        for p in &tol.abs_pos {
+            assert!((p.value() - 1e-6).abs() < 1e-22);
+        }
+        for v in &tol.abs_vel {
+            assert!((v.value() - 1e-9).abs() < 1e-25);
+        }
+    }
+}

--- a/qtty/tests/fixtures/qtty-vec-no-std-alloc/Cargo.lock
+++ b/qtty/tests/fixtures/qtty-vec-no-std-alloc/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "qtty"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "qtty-core",
  "qtty-derive",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "qtty-core"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "libm",
  "qtty-derive",
@@ -36,7 +36,7 @@ dependencies = [
 
 [[package]]
 name = "qtty-derive"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/qtty/tests/fixtures/qtty-vec-no-std/Cargo.lock
+++ b/qtty/tests/fixtures/qtty-vec-no-std/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "qtty"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "qtty-core",
  "qtty-derive",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "qtty-core"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "libm",
  "qtty-derive",
@@ -36,7 +36,7 @@ dependencies = [
 
 [[package]]
 name = "qtty-derive"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/qtty/tests/fixtures/qtty-vec-std/Cargo.lock
+++ b/qtty/tests/fixtures/qtty-vec-std/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "qtty"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "qtty-core",
  "qtty-derive",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "qtty-core"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "libm",
  "qtty-derive",
@@ -36,7 +36,7 @@ dependencies = [
 
 [[package]]
 name = "qtty-derive"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
This pull request introduces new modules and APIs to provide strongly-typed unit aliases, physical constants, and integration tolerances for astrodynamics and ODE integration, as well as new transcendental helpers and ratio operations for dimensionless quantities. These changes improve type safety, clarity, and usability for scientific and engineering applications that use the `qtty` crate.

The most important changes are:

**Astrodynamics Units, Constants, and Coefficients**  
* Added the new `dynamics` module, which defines type aliases for common astrodynamics units (e.g., `KmPerSecond`, `KmPerSecondSquared`, `InverseSecond`, `AreaToMassUnit`, and `GravitationalParameter`), physical constants for the gravitational parameters of Earth, Sun, and Moon, and newtype wrappers for semantic coefficients like `DragCoefficient`, `SrpCoefficient`, `J2Coefficient`, and `StokesCoefficient`. This ensures clear and type-safe usage of physical quantities and coefficients in astrodynamics code.

**Typed Integration Tolerances**  
* Introduced the `tolerances` module, with newtypes for `RelativeTolerance`, `AbsoluteTolerancePosition`, `AbsoluteToleranceVelocity`, and a combined `IntegratorTolerances` struct. These wrappers provide explicit, type-safe fields for ODE solver tolerances, preventing accidental mixing of relative and absolute tolerances and improving API clarity.

**Transcendental and Ratio Operations for Dimensionless Quantities**  
* Added new helper methods to `Quantity` for dimensionless units: `exp`, `ln`, `powi`, `powf`, and `ratio_to`. These allow for typed exponentiation, logarithms, and explicit ratio computations, returning results as dimensionless `Ratio` quantities for improved downstream type safety.

**Expanded Test Coverage**  
* Added comprehensive tests for the new ratio operations, transcendental helpers, and the astrodynamics/tolerances modules to ensure correct behavior and roundtrip accuracy. [[1]](diffhunk://#diff-953609e35ff0ad3dc9fda802d6031d70f25217f22e48df1561e9f299ff57a226R761-R825) [[2]](diffhunk://#diff-2a095ac88a6dd3818b7640cc1ffe735890b5f385edf5054acbabbf3b19ee567cR1-R277) [[3]](diffhunk://#diff-43689a2ac2e1acfd0d7c480a1331c943236efa16b2fa5b7b20c28a6812de0464R1-R208)

**Re-exports and Module Integration**  
* Updated the crate root (`lib.rs`) to publicly re-export the new units, constants, coefficients, and tolerances, and registered the new modules in the crate. Also added a missing re-export for the physical constant `C` (speed of light) in the `velocity` module. [[1]](diffhunk://#diff-da07603ed892a06c9a1cab77df3ce0ed65d7f0b1b7b8b3850de06cb54c015001R191-R201) [[2]](diffhunk://#diff-da07603ed892a06c9a1cab77df3ce0ed65d7f0b1b7b8b3850de06cb54c015001R394-R396) [[3]](diffhunk://#diff-da07603ed892a06c9a1cab77df3ce0ed65d7f0b1b7b8b3850de06cb54c015001R624-R625)

These changes provide a foundation for safer and more expressive scientific computation in downstream applications, especially in astrodynamics and numerical integration.