### PR TITLE
feat(dynamics): add GM constants for all major solar-system bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.8.1] - 22-05-2026
+
+### Added
+
+- GM_ for all planets
+- KmSquaredPerSecond, SpecificAngularMomentum, KmSquaredPerSecondSquared, SpecificOrbitalEnergy
+
 ## [0.8.0] - 12-05-2026
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,7 +708,7 @@ dependencies = [
 
 [[package]]
 name = "qtty"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "approx",
  "proptest",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "qtty-core"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "approx",
  "diesel",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "qtty-derive"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "proc-macro2",
  "qtty-core",
@@ -749,7 +749,7 @@ dependencies = [
 
 [[package]]
 name = "qtty-ffi"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "approx",
  "cbindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,9 +93,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bit-set"
@@ -289,9 +289,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "encoding_rs"
@@ -902,9 +902,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -1049,7 +1049,7 @@ dependencies = [
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -1076,7 +1076,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -1310,9 +1310,9 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["qtty-core", "qtty-derive", "qtty", "qtty-ffi"]
 resolver = "2"
 
 [workspace.package]
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 rust-version = "1.82"
 authors = ["VPRamon <vallespuigramon@gmail.com>"]

--- a/README.md
+++ b/README.md
@@ -64,28 +64,28 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-qtty = "0.8.0"
+qtty = "0.8.1"
 ```
 
 Minimal `no_std` build:
 
 ```toml
 [dependencies]
-qtty = { version = "0.8.0", default-features = false }
+qtty = { version = "0.8.1", default-features = false }
 ```
 
 `no_std` with heap-backed vectors/macros:
 
 ```toml
 [dependencies]
-qtty = { version = "0.8.0", default-features = false, features = ["alloc"] }
+qtty = { version = "0.8.1", default-features = false, features = ["alloc"] }
 ```
 
 Serde support:
 
 ```toml
 [dependencies]
-qtty = { version = "0.8.0", features = ["serde"] }
+qtty = { version = "0.8.1", features = ["serde"] }
 ```
 
 ---

--- a/qtty-core/README.md
+++ b/qtty-core/README.md
@@ -16,14 +16,14 @@ Install:
 
 ```toml
 [dependencies]
-qtty-core = "0.8.0"
+qtty-core = "0.8.1"
 ```
 
 Minimal `no_std`:
 
 ```toml
 [dependencies]
-qtty-core = { version = "0.8.0", default-features = false }
+qtty-core = { version = "0.8.1", default-features = false }
 ```
 
 Repository docs:

--- a/qtty-ffi/README.md
+++ b/qtty-ffi/README.md
@@ -19,7 +19,7 @@ registry without reimplementing conversion logic.
 
 ```toml
 [dependencies]
-qtty-ffi = "0.8.0"
+qtty-ffi = "0.8.1"
 ```
 
 ## C example

--- a/qtty-ffi/include/qtty_ffi.h
+++ b/qtty-ffi/include/qtty_ffi.h
@@ -2293,7 +2293,7 @@ const char *qtty_unit_name(uint32_t unit_id);
 /*
  Returns the FFI ABI version (major*10000 + minor*100 + patch).
 
- Current version: 0.8.0 → 800
+ Current version: 0.8.1 → 801
 
  The 0.8.x ABI extends the FFI unit catalog to cover the full `qtty`
  linear-unit inventory while continuing to use raw `u32` unit identifiers in

--- a/qtty-ffi/src/ffi/version.rs
+++ b/qtty-ffi/src/ffi/version.rs
@@ -3,7 +3,7 @@
 
 /// Returns the FFI ABI version (major*10000 + minor*100 + patch).
 ///
-/// Current version: 0.8.0 → 800
+/// Current version: 0.8.1 → 801
 ///
 /// The 0.7.x ABI extends the FFI unit catalog to cover the full `qtty`
 /// linear-unit inventory while continuing to use raw `u32` unit identifiers in
@@ -12,7 +12,7 @@
 #[allow(clippy::erasing_op, clippy::identity_op)]
 #[no_mangle]
 pub extern "C" fn qtty_ffi_version() -> u32 {
-    0 * 10000 + 8 * 100 + 0
+    0 * 10000 + 8 * 100 + 1
 }
 
 #[cfg(test)]
@@ -21,6 +21,6 @@ mod tests {
 
     #[test]
     fn test_version() {
-        assert_eq!(qtty_ffi_version(), 800);
+        assert_eq!(qtty_ffi_version(), 801);
     }
 }

--- a/qtty-ffi/tests/integration_tests.rs
+++ b/qtty-ffi/tests/integration_tests.rs
@@ -389,8 +389,8 @@ fn test_unit_name_invalid_id_returns_null() {
 
 #[test]
 fn test_ffi_version() {
-    // 0.8.0 → 800
-    assert_eq!(qtty_ffi_version(), 800);
+    // 0.8.1 → 801
+    assert_eq!(qtty_ffi_version(), 801);
 }
 
 // =============================================================================

--- a/qtty/README.md
+++ b/qtty/README.md
@@ -20,21 +20,21 @@ code without giving up ergonomics.
 
 ```toml
 [dependencies]
-qtty = "0.8.0"
+qtty = "0.8.1"
 ```
 
 Disable default features for `no_std`:
 
 ```toml
 [dependencies]
-qtty = { version = "0.8.0", default-features = false }
+qtty = { version = "0.8.1", default-features = false }
 ```
 
 Enable heap-backed helpers in `no_std`:
 
 ```toml
 [dependencies]
-qtty = { version = "0.8.0", default-features = false, features = ["alloc"] }
+qtty = { version = "0.8.1", default-features = false, features = ["alloc"] }
 ```
 
 ## Quick start

--- a/qtty/src/dynamics.rs
+++ b/qtty/src/dynamics.rs
@@ -25,6 +25,14 @@
 //! | [`GM_EARTH`] | 398 600.441 8 | EGM2008 / WGS-84 |
 //! | [`GM_SUN`] | 1.327 124 400 18 × 10¹¹ | IAU 2012 |
 //! | [`GM_MOON`] | 4.902 800 066 × 10³ | DE430 |
+//! | [`GM_MERCURY`] | 2.203 187 832 8 × 10⁴ | DE430 |
+//! | [`GM_VENUS`] | 3.248 585 920 0 × 10⁵ | DE430 |
+//! | [`GM_MARS`] | 4.282 837 581 6 × 10⁴ | DE430 |
+//! | [`GM_JUPITER`] | 1.267 127 648 0 × 10⁸ | DE430 |
+//! | [`GM_SATURN`] | 3.794 058 520 0 × 10⁷ | DE430 |
+//! | [`GM_URANUS`] | 5.794 548 600 0 × 10⁶ | DE430 |
+//! | [`GM_NEPTUNE`] | 6.836 527 100 5 × 10⁶ | DE430 |
+//! | [`GM_PLUTO`] | 9.770 × 10² | DE430 |
 //!
 //! ## Semantic coefficient newtypes
 //!
@@ -33,7 +41,7 @@
 //! accidental mixing of aerodynamic, solar-radiation-pressure, gravitational
 //! zonal, and tesseral/sectorial harmonic coefficients in force-model APIs.
 
-use qtty_core::units::area::SquareMeter;
+use qtty_core::units::area::{SquareKilometer, SquareMeter};
 use qtty_core::units::dimensionless::Ratio;
 use qtty_core::units::length::Kilometer;
 use qtty_core::units::mass::Kilogram;
@@ -60,6 +68,18 @@ pub type KmPerSecondSquared = Per<Per<Kilometer, Second>, Second>;
 
 /// Quantity alias: an acceleration in km/s².
 pub type KmPerSecondsSquared = Quantity<KmPerSecondSquared>;
+
+/// Unit marker for km²/s — specific angular momentum.
+pub type KmSquaredPerSecond = Per<SquareKilometer, Second>;
+
+/// Quantity alias: specific angular momentum in km²/s.
+pub type SpecificAngularMomentum = Quantity<KmSquaredPerSecond>;
+
+/// Unit marker for km²/s² — specific orbital energy.
+pub type KmSquaredPerSecondSquared = Per<SquareKilometer, Prod<Second, Second>>;
+
+/// Quantity alias: specific orbital energy in km²/s².
+pub type SpecificOrbitalEnergy = Quantity<KmSquaredPerSecondSquared>;
 
 /// Unit marker for inverse-second (1/s).
 ///
@@ -109,6 +129,46 @@ pub const GM_SUN: GravitationalParameter = GravitationalParameter::new(1.327_124
 ///
 /// μ_☾ = 4.902 800 066 × 10³ km³/s²
 pub const GM_MOON: GravitationalParameter = GravitationalParameter::new(4.902_800_066e3);
+
+/// Mercury standard gravitational parameter (DE430 value).
+///
+/// μ = 2.203 187 832 8 × 10⁴ km³/s²
+pub const GM_MERCURY: GravitationalParameter = GravitationalParameter::new(2.203_187_832_8e4);
+
+/// Venus standard gravitational parameter (DE430 value).
+///
+/// μ = 3.248 585 920 0 × 10⁵ km³/s²
+pub const GM_VENUS: GravitationalParameter = GravitationalParameter::new(3.248_585_920_0e5);
+
+/// Mars system standard gravitational parameter (DE430 value, Mars + Phobos + Deimos).
+///
+/// μ = 4.282 837 581 6 × 10⁴ km³/s²
+pub const GM_MARS: GravitationalParameter = GravitationalParameter::new(4.282_837_581_6e4);
+
+/// Jupiter system standard gravitational parameter (DE430 value, Jupiter + all moons).
+///
+/// μ = 1.267 127 648 0 × 10⁸ km³/s²
+pub const GM_JUPITER: GravitationalParameter = GravitationalParameter::new(1.267_127_648_0e8);
+
+/// Saturn system standard gravitational parameter (DE430 value, Saturn + all moons).
+///
+/// μ = 3.794 058 520 0 × 10⁷ km³/s²
+pub const GM_SATURN: GravitationalParameter = GravitationalParameter::new(3.794_058_520_0e7);
+
+/// Uranus system standard gravitational parameter (DE430 value, Uranus + all moons).
+///
+/// μ = 5.794 548 600 0 × 10⁶ km³/s²
+pub const GM_URANUS: GravitationalParameter = GravitationalParameter::new(5.794_548_600_0e6);
+
+/// Neptune system standard gravitational parameter (DE430 value, Neptune + all moons).
+///
+/// μ = 6.836 527 100 5 × 10⁶ km³/s²
+pub const GM_NEPTUNE: GravitationalParameter = GravitationalParameter::new(6.836_527_100_5e6);
+
+/// Pluto system standard gravitational parameter (DE430 value, Pluto + Charon).
+///
+/// μ = 9.770 × 10² km³/s²
+pub const GM_PLUTO: GravitationalParameter = GravitationalParameter::new(9.770e2);
 
 /// Speed of light in vacuum (km/s).
 ///

--- a/qtty/src/lib.rs
+++ b/qtty/src/lib.rs
@@ -195,8 +195,10 @@ pub use qtty_core::{
 pub use dynamics::{
     AreaToMass, AreaToMassUnit, DragCoefficient, GravitationalParameter,
     GravitationalParameterUnit, InverseSecond, InverseSeconds, J2Coefficient, KmPerSecond,
-    KmPerSecondSquared, KmPerSeconds, KmPerSecondsSquared, SrpCoefficient, StokesCoefficient,
-    GM_EARTH, GM_MOON, GM_SUN,
+    KmPerSecondSquared, KmPerSeconds, KmPerSecondsSquared, KmSquaredPerSecond,
+    KmSquaredPerSecondSquared, SpecificAngularMomentum, SpecificOrbitalEnergy, SrpCoefficient,
+    StokesCoefficient, GM_EARTH, GM_JUPITER, GM_MARS, GM_MERCURY, GM_MOON, GM_NEPTUNE, GM_PLUTO,
+    GM_SATURN, GM_SUN, GM_URANUS, GM_VENUS,
 };
 
 #[cfg(feature = "satellite")]


### PR DESCRIPTION
Add standard gravitational parameter constants (km³/s²) for Mercury, Venus, Mars, Jupiter, Saturn, Uranus, Neptune, and Pluto to qtty::dynamics using JPL DE430 values.

Re-export all new GM_* constants from qtty::lib so downstream crates can use them via the root qtty namespace.